### PR TITLE
Added .bumpedrc

### DIFF
--- a/.bumpedrc
+++ b/.bumpedrc
@@ -25,3 +25,12 @@ plugins:
     'Committing the new version':
       plugin: 'bumped-terminal'
       command: 'git add . && git commit -m "$newVersion releases"'
+
+    'Publishing at Github':
+      plugin: 'bumped-terminal'
+      command: 'git tag $newVersion && git push --tags && git push origin master'
+
+    'Publishing at NPM':
+      plugin: 'bumped-terminal'
+      command: 'npm publish'
+

--- a/.bumpedrc
+++ b/.bumpedrc
@@ -22,15 +22,14 @@ plugins:
     'Generating CHANGELOG file':
       plugin: 'bumped-changelog'
 
-    'Committing the new version':
+    'Publishing CHANGELOG at Github':
       plugin: 'bumped-terminal'
-      command: 'git add . && git commit -m "$newVersion releases"'
+      command: 'git add CHANGELOG.md && git commit CHANGELOG.md -m "$newVersion release" && git push origin master'
 
-    'Publishing at Github':
+    'Publishing tag at Github':
       plugin: 'bumped-terminal'
-      command: 'git tag $newVersion && git push --tags && git push origin master'
+      command: 'git tag $newVersion && git push origin $newVersion'
 
     'Publishing at NPM':
       plugin: 'bumped-terminal'
       command: 'npm publish'
-

--- a/.bumpedrc
+++ b/.bumpedrc
@@ -1,0 +1,27 @@
+files: [
+  'package.json'
+]
+
+plugins:
+
+  prerelease:
+
+    'Linting config files':
+      plugin: 'bumped-finepack'
+
+    'Linting projects files':
+      plugin: 'bumped-terminal'
+      command: 'npm run lint'
+
+    'Preparing build':
+      plugin: 'bumped-terminal'
+      command: 'npm run prepublish'
+
+  postrelease:
+
+    'Generating CHANGELOG file':
+      plugin: 'bumped-changelog'
+
+    'Committing the new version':
+      plugin: 'bumped-terminal'
+      command: 'git add . && git commit -m "$newVersion releases"'


### PR DESCRIPTION
I added [bumped](https://github.com/bumped/bumped#bumped) command to be more easy release a new software of the repository. Just need to follow this two steps the next time that you want to release a new version:

1) install it with `npm install -g bumped`
2) when you need to release a version, type `bumped release major|minor|path` and automatically bumped create the build ready to be released :D

The current configuration automatically lint projects and config files, generate the changelog and make a commit with the new version.

Additionally you can edit `.bumpedrc` and add another postrelease command to generate `git tag` and `npm publish`, but I prefer do this steps manually. Up to you!