### PR TITLE
Include pure implementations of each stateful component

### DIFF
--- a/components/checkbox/index.jsx
+++ b/components/checkbox/index.jsx
@@ -4,6 +4,41 @@ import events from '../utils/events';
 import style from './style';
 
 class Checkbox extends React.Component {
+
+  static defaultProps = {
+    checked: false
+  }
+
+  state = {
+    checked: this.props.checked
+  }
+
+  onChange = (event) => {
+    this.setState({checked: !this.state.checked}, () => {
+      if (this.props.onChange) this.props.onChange(event, this);
+    });
+  };
+
+  render () {
+    return <PureCheckbox
+      {...this.props}
+      onChange={this.onChange.bind(this)}
+      checked={this.state.checked}
+      />;
+  }
+
+  getValue () {
+    return this.state.checked;
+  }
+
+  setValue (value) {
+    this.setState({checked: value});
+  }
+
+}
+
+export
+class PureCheckbox extends React.Component {
   static propTypes = {
     checked: React.PropTypes.bool,
     className: React.PropTypes.string,
@@ -21,19 +56,10 @@ class Checkbox extends React.Component {
     disabled: false
   };
 
-  state = {
-    checked: this.props.checked
-  };
-
-  handleChange = (event) => {
-    this.setState({checked: !this.state.checked}, () => {
-      if (this.props.onChange) this.props.onChange(event, this);
-    });
-  };
 
   handleClick = (event) => {
     events.pauseEvent(event);
-    if (!this.props.disabled) this.handleChange(event);
+    if (!this.props.disabled) this.props.onChange(event);
   };
 
   handleMouseDown = (event) => {
@@ -47,7 +73,7 @@ class Checkbox extends React.Component {
   render () {
     let fieldClassName = style.field;
     let checkboxClassName = style.check;
-    if (this.state.checked) checkboxClassName += ` ${style.checked}`;
+    if (this.props.checked) checkboxClassName += ` ${style.checked}`;
     if (this.props.disabled) fieldClassName += ` ${style.disabled}`;
     if (this.props.className) fieldClassName += ` ${this.props.className}`;
 
@@ -62,8 +88,6 @@ class Checkbox extends React.Component {
           ref='input'
           type='checkbox'
           className={style.input}
-          checked={this.state.checked}
-          onChange={this.handleChange}
           onClick={this.handleInputClick}
         />
         <span data-role='checkbox' className={checkboxClassName} onMouseDown={this.handleMouseDown}>
@@ -82,13 +106,6 @@ class Checkbox extends React.Component {
     this.refs.input.focus();
   }
 
-  getValue () {
-    return this.state.checked;
-  }
-
-  setValue (value) {
-    this.setState({checked: value});
-  }
 }
 
 export default Checkbox;


### PR DESCRIPTION
I'm super excited to have come across this project on echojs.com! I've been toying with creating something very similar because the existing react implementations of material design aren't quite right for my use cases. This project almost perfectly matches though! so yay!

The one thing that would make it perfect for me would be if all components could be entirely driven by props. An example of this (and where material-ui didn't quite work) is the Dialog component. Where the open/closed state is store internally and changed via a function call. There are ways to work around this but it generally results in a lot of extra code wrapping each component and becomes hard to maintain. 

I'm using https://github.com/rackt/redux and friends and really trying to get to the level of purity where the entire rendered application is a reflection purely of state stored in the Redux store.

This PR contains an example of exporting both a stateful Checkbox and a PureCheckbox. The default is still the stateful so most users will get a checkbox that functions "normally". But for users such as myself that are looking to store state entirely external to the react components, the pure option is available.

This is just an example of a single component in order to get your feedback and see if this is an approach that you would be willing/interested in going with.

Awesome work!