### PR TITLE
Fix disabled ripple click error

### DIFF
--- a/components/button/index.jsx
+++ b/components/button/index.jsx
@@ -33,7 +33,7 @@ class Button extends React.Component {
 
   handleMouseDown = (event) => {
     events.pauseEvent(event);
-    this.refs.ripple.start(event);
+    if (this.refs.ripple) this.refs.ripple.start(event);
     if (this.props.onMouseDown) this.props.onMouseDown(event);
   };
 


### PR DESCRIPTION
If ripple prop is false, this.refs.ripple will be undefined and will throw a TypeError every time handleMouseDown is called.