### PR TITLE
[autocomplete] Fix #134

### DIFF
--- a/components/autocomplete/index.jsx
+++ b/components/autocomplete/index.jsx
@@ -59,7 +59,7 @@ class Autocomplete extends React.Component {
   };
 
   handleQueryChange = (event) => {
-    this.setState({event: event.target.value});
+    this.setState({query: event.target.value});
   };
 
   handleQueryFocus = () => {


### PR DESCRIPTION
# Autocomplete

## Bug

Impossible to input some text.

## Patch

The `state` attribute set in the change handler was wrong, had to change it from `event` to `query`.