### PR TITLE
no need padding-bottom on input error

### DIFF
--- a/components/input/style.scss
+++ b/components/input/style.scss
@@ -115,7 +115,6 @@
 }
 
 .errored {
-  padding-bottom: 0;
   > .input {
     border-bottom-color: $input-text-error-color;
     &:focus {


### PR DESCRIPTION
<img width="399" alt="screen shot 2015-11-29 at 5 52 56 pm" src="https://cloud.githubusercontent.com/assets/1642957/11456403/823c8a44-96c2-11e5-97e7-81ea6bc55362.png">
<img width="166" alt="screen shot 2015-11-29 at 5 53 20 pm" src="https://cloud.githubusercontent.com/assets/1642957/11456402/823adffa-96c2-11e5-973c-8b52ea0b930b.png">

the error on a wrong padding-bottom