### PR TITLE
Fix ripple positioning when page is scrolled

### DIFF
--- a/components/ripple/Ripple.jsx
+++ b/components/ripple/Ripple.jsx
@@ -51,8 +51,8 @@ class Ripple extends React.Component {
   _getDescriptor (pageX, pageY) {
     const {left, top, height, width} = ReactDOM.findDOMNode(this).getBoundingClientRect();
     return {
-      left: this.props.centered ? 0 : pageX - left - width / 2 + window.scrollX,
-      top: this.props.centered ? 0 : pageY - top - height / 2 + window.scrollY,
+      left: this.props.centered ? 0 : pageX - left - width / 2 - window.scrollX,
+      top: this.props.centered ? 0 : pageY - top - height / 2 - window.scrollY,
       width: width * this.props.spread
     };
   }


### PR DESCRIPTION
When the page is scrolled, the ripple position gets off and is not visible after scrolling few pixels. This PR fixes that behavior, so that the ripple stays where it should