### PR TITLE
Prevent avatar from getting squeezed

### DIFF
--- a/components/list/style.scss
+++ b/components/list/style.scss
@@ -102,6 +102,7 @@
 
 .avatar {
   display: flex;
+  flex: 0 0 auto;
   width: $list-item-avatar-height;
   height: $list-item-avatar-height;
   margin: $list-item-avatar-margin $list-horizontal-padding $list-item-avatar-margin 0;


### PR DESCRIPTION
If caption or legend of a list item with an avatar are very long, the avatar got squeezed, because it was allowed to shrink in its flex container.