### PR TITLE
Add maxLength attribute to input component

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -79,7 +79,8 @@ class Input extends React.Component {
       role: 'input',
       disabled,
       type,
-      value
+      value,
+      maxLength
     });
 
     return (


### PR DESCRIPTION
@javivelasco The maxLength attribute was not working, and it was because it was being displayed but not being added to the element.