### PR TITLE
customizable list

### DIFF
--- a/components/list/ListCheckbox.jsx
+++ b/components/list/ListCheckbox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ClassNames from 'classnames';
 import Checkbox from '../checkbox';
-import ListItemContent from './ListItemContent';
+import ListItemMiddle from './ListItemMiddle';
 import style from './style';
 
 const ListCheckbox = (props) => {
@@ -16,7 +16,7 @@ const ListCheckbox = (props) => {
         checked={props.checked}
         className={style.checkbox}
         disabled={props.disabled}
-        label={<ListItemContent caption={props.caption} legend={props.legend} />}
+        label={<ListItemMiddle caption={props.caption} legend={props.legend} />}
         name={props.name}
         onBlur={props.onBlur}
         onChange={props.onChange}

--- a/components/list/ListItem.jsx
+++ b/components/list/ListItem.jsx
@@ -7,6 +7,7 @@ import ListItemMiddle from './ListItemMiddle';
 import ListItemLeft from './ListItemLeft'
 import ListItemRight from './ListItemRight'
 import ListItemAvatar from './ListItemAvatar'
+import ReservedChildren from '../reserved_children/ReservedChildren'
 
 class ListItem extends React.Component {
   static propTypes = {
@@ -22,23 +23,6 @@ class ListItem extends React.Component {
     selectable: false
   };
 
-  reservedChildrenTypes = new Set([ListItemMiddle, ListItemLeft, ListItemRight, ListItemAvatar]);
-
-  isReservedChild (child) {
-    return child && this.reservedChildrenTypes.has(child.type);
-  }
-
-  reservedChildren () {
-    let children = {};
-    React.Children.forEach(this.props.children, (child) => {
-      if (this.isReservedChild(child)) {
-        children[child.type] = child;
-      }
-    });
-
-    return children;
-  }
-
   handleClick = (event) => {
     if (this.props.onClick && !this.props.disabled) {
       this.props.onClick(event);
@@ -47,17 +31,18 @@ class ListItem extends React.Component {
 
   render () {
     const {onClick, ripple, selectable, to, ...other} = this.props;
-    const content = <ListItemContent {...other} reservedChildren={this.reservedChildren()}/>;
+    const content = <ListItemContent {...other} reservedChildren={this.reservedChildrenByType()}/>;
     return (
       <li className={style.listItem} onClick={this.handleClick} onMouseDown={this.props.onMouseDown}>
         {this.props.to ? <a href={this.props.to}>{content}</a> : content}
-        {React.Children.toArray(this.props.children).filter((child) => !this.isReservedChild(child))}
+        {this.unreservedChildren()}
       </li>
     );
   }
 }
 
+const ListItemWithReservedChildren = ReservedChildren(ListItem, [ListItemMiddle, ListItemLeft, ListItemRight, ListItemAvatar]);
 export default Ripple({
   className: style.ripple,
   centered: false
-})(ListItem);
+})(ListItemWithReservedChildren);

--- a/components/list/ListItem.jsx
+++ b/components/list/ListItem.jsx
@@ -1,26 +1,16 @@
 import React from 'react';
 import ClassNames from 'classnames';
-import FontIcon from '../font_icon';
-import ListItemContent from './ListItemContent';
-import ListItemLeft from './ListItemLeft'
-import ListItemRight from './ListItemRight'
-import ListItemCaption from './ListItemCaption'
-import ListItemLegend from './ListItemLegend'
-import ListItemAvatar from './ListItemAvatar'
 import Ripple from '../ripple';
 import style from './style';
+import ListItemContent from './ListItemContent';
+import ListItemMiddle from './ListItemMiddle';
+import ListItemLeft from './ListItemLeft'
+import ListItemRight from './ListItemRight'
+import ListItemAvatar from './ListItemAvatar'
 
 class ListItem extends React.Component {
   static propTypes = {
-    avatar: React.PropTypes.string,
-    caption: React.PropTypes.string,
-    children: React.PropTypes.any,
-    className: React.PropTypes.string,
-    disabled: React.PropTypes.bool,
-    leftIcon: React.PropTypes.string,
-    legend: React.PropTypes.string,
     onClick: React.PropTypes.func,
-    rightIcon: React.PropTypes.string,
     ripple: React.PropTypes.bool,
     selectable: React.PropTypes.bool,
     to: React.PropTypes.string
@@ -32,19 +22,13 @@ class ListItem extends React.Component {
     selectable: false
   };
 
-  reservedChildrenTypes = new Set([ListItemLeft, ListItemRight, ListItemCaption, ListItemLegend, ListItemAvatar]);
+  reservedChildrenTypes = new Set([ListItemMiddle, ListItemLeft, ListItemRight, ListItemAvatar]);
 
-  handleClick = (event) => {
-    if (this.props.onClick && !this.props.disabled) {
-      this.props.onClick(event);
-    }
-  };
-
-  isReservedChild(child) {
+  isReservedChild (child) {
     return child && this.reservedChildrenTypes.has(child.type);
   }
 
-  reservedChildren() {
+  reservedChildren () {
     let children = {};
     React.Children.forEach(this.props.children, (child) => {
       if (this.isReservedChild(child)) {
@@ -52,40 +36,21 @@ class ListItem extends React.Component {
       }
     });
 
-    return children; 
+    return children;
   }
 
-  renderContent () {
-    const className = ClassNames(style.item, {
-      [style.withLegend]: this.props.legend,
-      [style.disabled]: this.props.disabled,
-      [style.selectable]: this.props.selectable
-    }, this.props.className);
-
-    const defaultLeftElement = this.props.leftIcon ? <ListItemLeft><FontIcon value={this.props.leftIcon} /></ListItemLeft> : null;
-    const defaultRightElement = this.props.rightIcon ? <ListItemRight><FontIcon value={this.props.rightIcon} /></ListItemRight> : null;
-    const defaultCaption = <ListItemCaption> {this.props.caption} </ListItemCaption>;
-    const defaultLegend = <ListItemLegend> {this.props.legend} </ListItemLegend>;
-    const defaultAvatar = this.props.avatar? <ListItemAvatar> <img src={this.props.avatar} /> </ListItemAvatar> : null;
-    const reservedChildren = this.reservedChildren();
-
-    return (
-      <span className={className}>
-        {reservedChildren[ListItemLeft] || defaultLeftElement}
-        {reservedChildren[ListItemAvatar] || defaultAvatar}
-        <ListItemContent>
-          {reservedChildren[ListItemCaption] || defaultCaption}
-          {reservedChildren[ListItemLegend] || defaultLegend}
-        </ListItemContent>
-        {reservedChildren[ListItemRight] || defaultRightElement}
-      </span>
-    );
-  }
+  handleClick = (event) => {
+    if (this.props.onClick && !this.props.disabled) {
+      this.props.onClick(event);
+    }
+  };
 
   render () {
+    const {onClick, ripple, selectable, to, ...other} = this.props;
+    const content = <ListItemContent {...other} reservedChildren={this.reservedChildren()}/>;
     return (
       <li className={style.listItem} onClick={this.handleClick} onMouseDown={this.props.onMouseDown}>
-        {this.props.to ? <a href={this.props.to}>{this.renderContent()}</a> : this.renderContent()}
+        {this.props.to ? <a href={this.props.to}>{content}</a> : content}
         {React.Children.toArray(this.props.children).filter((child) => !this.isReservedChild(child))}
       </li>
     );

--- a/components/list/ListItem.jsx
+++ b/components/list/ListItem.jsx
@@ -1,26 +1,24 @@
 import React from 'react';
-import ClassNames from 'classnames';
 import Ripple from '../ripple';
 import style from './style';
 import ListItemContent from './ListItemContent';
 import ListItemMiddle from './ListItemMiddle';
-import ListItemLeft from './ListItemLeft'
-import ListItemRight from './ListItemRight'
-import ListItemAvatar from './ListItemAvatar'
-import ReservedChildren from '../reserved_children/ReservedChildren'
+import ListItemLeft from './ListItemLeft';
+import ListItemRight from './ListItemRight';
+import ListItemAvatar from './ListItemAvatar';
+import ReservedChildren from '../reserved_children/ReservedChildren';
 
 class ListItem extends React.Component {
   static propTypes = {
+    disabled: React.PropTypes.bool,
     onClick: React.PropTypes.func,
     ripple: React.PropTypes.bool,
-    selectable: React.PropTypes.bool,
     to: React.PropTypes.string
   };
 
   static defaultProps = {
     disabled: false,
-    ripple: false,
-    selectable: false
+    ripple: false
   };
 
   handleClick = (event) => {
@@ -30,7 +28,7 @@ class ListItem extends React.Component {
   };
 
   render () {
-    const {onClick, ripple, selectable, to, ...other} = this.props;
+    const {onClick, ripple, to, ...other} = this.props;
     const content = <ListItemContent {...other} reservedChildren={this.reservedChildrenByType()}/>;
     return (
       <li className={style.listItem} onClick={this.handleClick} onMouseDown={this.props.onMouseDown}>

--- a/components/list/ListItemAvatar.jsx
+++ b/components/list/ListItemAvatar.jsx
@@ -3,6 +3,6 @@ import style from './style';
 
 const ListItemAvatar = ({children}) => {
   return <span className={style.avatar}> {children} </span>;
-}
+};
 
 export default ListItemAvatar;

--- a/components/list/ListItemAvatar.jsx
+++ b/components/list/ListItemAvatar.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import style from './style';
+
+const ListItemAvatar = ({children}) => {
+  return <span className={style.avatar}> {children} </span>;
+}
+
+export default ListItemAvatar;

--- a/components/list/ListItemCaption.jsx
+++ b/components/list/ListItemCaption.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import style from './style';
+
+const ListItemCaption = ({children}) => {
+  return <span className={style.caption}> {children} </span>;
+}
+
+export default ListItemCaption;

--- a/components/list/ListItemCaption.jsx
+++ b/components/list/ListItemCaption.jsx
@@ -3,6 +3,6 @@ import style from './style';
 
 const ListItemCaption = ({children}) => {
   return <span className={style.caption}> {children} </span>;
-}
+};
 
 export default ListItemCaption;

--- a/components/list/ListItemContent.jsx
+++ b/components/list/ListItemContent.jsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import style from './style';
 
-const ListItemContent = ({caption, legend}) => (
-  <span className={style.text}>
-    <span className={style.caption}>{caption}</span>
-    <span className={style.legend}>{legend}</span>
-  </span>
+const ListItemContent = ({children}) => (
+  <span className={style.text}> {children} </span>
 );
-
-ListItemContent.propTypes = {
-  caption: React.PropTypes.string.isRequired,
-  legend: React.PropTypes.any
-};
 
 export default ListItemContent;

--- a/components/list/ListItemContent.jsx
+++ b/components/list/ListItemContent.jsx
@@ -1,8 +1,45 @@
 import React from 'react';
 import style from './style';
+import ClassNames from 'classnames';
+import FontIcon from '../font_icon';
+import ListItemMiddle from './ListItemMiddle';
+import ListItemLeft from './ListItemLeft'
+import ListItemRight from './ListItemRight'
+import ListItemAvatar from './ListItemAvatar'
 
-const ListItemContent = ({children}) => (
-  <span className={style.text}> {children} </span>
-);
+class ListItemContent extends React.Component {
+  static propTypes = {
+    avatar: React.PropTypes.string,
+    caption: React.PropTypes.string,
+    className: React.PropTypes.string,
+    disabled: React.PropTypes.bool,
+    leftIcon: React.PropTypes.string,
+    legend: React.PropTypes.string,
+    rightIcon: React.PropTypes.string,
+    reservedChildren: React.PropTypes.object
+  };
+
+  render() {
+    const className = ClassNames(style.item, {
+      [style.withLegend]: this.props.legend,
+      [style.disabled]: this.props.disabled,
+      [style.selectable]: this.props.selectable
+    }, this.props.className);
+
+    const defaultLeftElement = this.props.leftIcon ? <ListItemLeft><FontIcon value={this.props.leftIcon} /></ListItemLeft> : null;
+    const defaultRightElement = this.props.rightIcon ? <ListItemRight><FontIcon value={this.props.rightIcon} /></ListItemRight> : null;
+    const defaultMiddleElement = <ListItemMiddle caption={this.props.caption} legend={this.props.legend}/>;
+    const defaultAvatar = this.props.avatar? <ListItemAvatar> <img src={this.props.avatar} /> </ListItemAvatar> : null;
+
+    return (
+      <span className={className}>
+        {this.props.reservedChildren[ListItemLeft] || defaultLeftElement}
+        {this.props.reservedChildren[ListItemAvatar] || defaultAvatar}
+        {this.props.reservedChildren[ListItemMiddle] || defaultMiddleElement}
+        {this.props.reservedChildren[ListItemRight] || defaultRightElement}
+      </span>
+    );
+  }
+}
 
 export default ListItemContent;

--- a/components/list/ListItemContent.jsx
+++ b/components/list/ListItemContent.jsx
@@ -3,9 +3,9 @@ import style from './style';
 import ClassNames from 'classnames';
 import FontIcon from '../font_icon';
 import ListItemMiddle from './ListItemMiddle';
-import ListItemLeft from './ListItemLeft'
-import ListItemRight from './ListItemRight'
-import ListItemAvatar from './ListItemAvatar'
+import ListItemLeft from './ListItemLeft';
+import ListItemRight from './ListItemRight';
+import ListItemAvatar from './ListItemAvatar';
 
 class ListItemContent extends React.Component {
   static propTypes = {
@@ -15,11 +15,17 @@ class ListItemContent extends React.Component {
     disabled: React.PropTypes.bool,
     leftIcon: React.PropTypes.string,
     legend: React.PropTypes.string,
+    reservedChildren: React.PropTypes.object,
     rightIcon: React.PropTypes.string,
-    reservedChildren: React.PropTypes.object
+    selectable: React.PropTypes.bool
   };
 
-  render() {
+  static defaultProps = {
+    disabled: false,
+    selectable: false
+  };
+
+  render () {
     const className = ClassNames(style.item, {
       [style.withLegend]: this.props.legend,
       [style.disabled]: this.props.disabled,
@@ -29,7 +35,7 @@ class ListItemContent extends React.Component {
     const defaultLeftElement = this.props.leftIcon ? <ListItemLeft><FontIcon value={this.props.leftIcon} /></ListItemLeft> : null;
     const defaultRightElement = this.props.rightIcon ? <ListItemRight><FontIcon value={this.props.rightIcon} /></ListItemRight> : null;
     const defaultMiddleElement = <ListItemMiddle caption={this.props.caption} legend={this.props.legend}/>;
-    const defaultAvatar = this.props.avatar? <ListItemAvatar> <img src={this.props.avatar} /> </ListItemAvatar> : null;
+    const defaultAvatar = this.props.avatar ? <ListItemAvatar> <img src={this.props.avatar} /> </ListItemAvatar> : null;
 
     return (
       <span className={className}>

--- a/components/list/ListItemLeft.jsx
+++ b/components/list/ListItemLeft.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import style from './style';
+
+
+const ListItemLeft = ({children}) => {
+  return <div className={`${style.icon} ${style.left}`}> {children} </div>;
+}
+
+export default ListItemLeft;

--- a/components/list/ListItemLeft.jsx
+++ b/components/list/ListItemLeft.jsx
@@ -4,6 +4,6 @@ import style from './style';
 
 const ListItemLeft = ({children}) => {
   return <div className={`${style.icon} ${style.left}`}> {children} </div>;
-}
+};
 
 export default ListItemLeft;

--- a/components/list/ListItemLegend.jsx
+++ b/components/list/ListItemLegend.jsx
@@ -3,6 +3,6 @@ import style from './style';
 
 const ListItemLegend = ({children}) => {
   return <span className={style.legend}> {children} </span>;
-}
+};
 
 export default ListItemLegend;

--- a/components/list/ListItemLegend.jsx
+++ b/components/list/ListItemLegend.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import style from './style';
+
+const ListItemLegend = ({children}) => {
+  return <span className={style.legend}> {children} </span>;
+}
+
+export default ListItemLegend;

--- a/components/list/ListItemMiddle.jsx
+++ b/components/list/ListItemMiddle.jsx
@@ -7,7 +7,7 @@ import ReservedChildren from '../reserved_children/ReservedChildren';
 class ListItemMiddle extends React.Component {
   static propTypes = {
     caption: React.PropTypes.string,
-    legend: React.PropTypes.string,
+    legend: React.PropTypes.string
   };
 
   render () {

--- a/components/list/ListItemMiddle.jsx
+++ b/components/list/ListItemMiddle.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import style from './style';
+import ListItemCaption from './ListItemCaption'
+import ListItemLegend from './ListItemLegend'
+
+class ListItemMiddle extends React.Component {
+  reservedChildrenTypes = new Set([ListItemCaption, ListItemLegend]);
+
+  isReservedChild (child) {
+    return child && this.reservedChildrenTypes.has(child.type);
+  }
+
+  reservedChildren () {
+    let children = {};
+    React.Children.forEach(this.props.children, (child) => {
+      if (this.isReservedChild(child)) {
+        children[child.type] = child;
+      }
+    });
+
+    return children;
+  }
+
+  render () {
+    const defaultCaption = <ListItemCaption> {this.props.caption} </ListItemCaption>;
+    const defaultLegend = <ListItemLegend> {this.props.legend} </ListItemLegend>;
+    const reservedChildren = this.reservedChildren();
+
+    return (
+      <span className={style.text}>
+        {reservedChildren[ListItemCaption] || defaultCaption}
+        {reservedChildren[ListItemLegend] || defaultLegend}
+      </span>
+    );
+  }
+}
+
+export default ListItemMiddle;

--- a/components/list/ListItemMiddle.jsx
+++ b/components/list/ListItemMiddle.jsx
@@ -5,6 +5,11 @@ import ListItemLegend from './ListItemLegend';
 import ReservedChildren from '../reserved_children/ReservedChildren';
 
 class ListItemMiddle extends React.Component {
+  static propTypes = {
+    caption: React.PropTypes.string,
+    legend: React.PropTypes.string,
+  };
+
   render () {
     const defaultCaption = <ListItemCaption> {this.props.caption} </ListItemCaption>;
     const defaultLegend = <ListItemLegend> {this.props.legend} </ListItemLegend>;

--- a/components/list/ListItemMiddle.jsx
+++ b/components/list/ListItemMiddle.jsx
@@ -1,30 +1,14 @@
 import React from 'react';
 import style from './style';
-import ListItemCaption from './ListItemCaption'
-import ListItemLegend from './ListItemLegend'
+import ListItemCaption from './ListItemCaption';
+import ListItemLegend from './ListItemLegend';
+import ReservedChildren from '../reserved_children/ReservedChildren';
 
 class ListItemMiddle extends React.Component {
-  reservedChildrenTypes = new Set([ListItemCaption, ListItemLegend]);
-
-  isReservedChild (child) {
-    return child && this.reservedChildrenTypes.has(child.type);
-  }
-
-  reservedChildren () {
-    let children = {};
-    React.Children.forEach(this.props.children, (child) => {
-      if (this.isReservedChild(child)) {
-        children[child.type] = child;
-      }
-    });
-
-    return children;
-  }
-
   render () {
     const defaultCaption = <ListItemCaption> {this.props.caption} </ListItemCaption>;
     const defaultLegend = <ListItemLegend> {this.props.legend} </ListItemLegend>;
-    const reservedChildren = this.reservedChildren();
+    const reservedChildren = this.reservedChildrenByType();
 
     return (
       <span className={style.text}>
@@ -35,4 +19,4 @@ class ListItemMiddle extends React.Component {
   }
 }
 
-export default ListItemMiddle;
+export default ReservedChildren(ListItemMiddle, [ListItemCaption, ListItemLegend]);

--- a/components/list/ListItemRight.jsx
+++ b/components/list/ListItemRight.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import style from './style';
+
+const ListItemRight = ({children}) => {
+ return  <div className={`${style.icon} ${style.right}`}> {children} </div>;
+}
+
+export default ListItemRight;

--- a/components/list/ListItemRight.jsx
+++ b/components/list/ListItemRight.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import style from './style';
 
 const ListItemRight = ({children}) => {
- return  <div className={`${style.icon} ${style.right}`}> {children} </div>;
-}
+ return <div className={`${style.icon} ${style.right}`}> {children} </div>;
+};
 
 export default ListItemRight;

--- a/components/list/index.js
+++ b/components/list/index.js
@@ -5,6 +5,7 @@ export ListCheckbox from './ListCheckbox';
 export ListSubHeader from './ListSubHeader';
 export ListItemLeft from './ListItemLeft';
 export ListItemRight from './ListItemRight';
+export ListItemMiddle from './ListItemMiddle';
 export ListItemCaption from './ListItemCaption';
 export ListItemLegend from './ListItemLegend';
 export ListItemAvatar from './ListItemAvatar'

--- a/components/list/index.js
+++ b/components/list/index.js
@@ -8,4 +8,4 @@ export ListItemRight from './ListItemRight';
 export ListItemMiddle from './ListItemMiddle';
 export ListItemCaption from './ListItemCaption';
 export ListItemLegend from './ListItemLegend';
-export ListItemAvatar from './ListItemAvatar'
+export ListItemAvatar from './ListItemAvatar';

--- a/components/list/index.js
+++ b/components/list/index.js
@@ -3,3 +3,8 @@ export ListItem from './ListItem';
 export ListDivider from './ListDivider';
 export ListCheckbox from './ListCheckbox';
 export ListSubHeader from './ListSubHeader';
+export ListItemLeft from './ListItemLeft';
+export ListItemRight from './ListItemRight';
+export ListItemCaption from './ListItemCaption';
+export ListItemLegend from './ListItemLegend';
+export ListItemAvatar from './ListItemAvatar'

--- a/components/list/style.scss
+++ b/components/list/style.scss
@@ -106,7 +106,7 @@
   white-space: normal;
 }
 
-.avatar {
+.avatar img{
   display: flex;
   width: $list-item-avatar-height;
   height: $list-item-avatar-height;

--- a/components/reserved_children/ReservedChildren.jsx
+++ b/components/reserved_children/ReservedChildren.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const ReservedChildren = (ComposedComponent, reservedChildrenTypes) => {
+  return class ComponentWithReservedChildren extends ComposedComponent {
+    reservedChildrenTypes = new Set(reservedChildrenTypes);
+
+    isReservedChild (child) {
+      return child && this.reservedChildrenTypes.has(child.type);
+    }
+
+    reservedChildrenByType () {
+      let children = {};
+      React.Children.forEach(this.props.children, (child) => {
+        if (this.isReservedChild(child)) {
+          children[child.type] = child;
+        }
+      });
+
+      return children;
+    }
+
+    unreservedChildren () {
+      let children = React.Children.toArray(this.props.children);
+
+      return children.filter((child) => !this.isReservedChild(child))
+    }
+  }
+}
+
+
+export default ReservedChildren;

--- a/components/reserved_children/ReservedChildren.jsx
+++ b/components/reserved_children/ReservedChildren.jsx
@@ -9,7 +9,7 @@ const ReservedChildren = (ComposedComponent, reservedChildrenTypes) => {
     }
 
     reservedChildrenByType () {
-      let children = {};
+      const children = {};
       React.Children.forEach(this.props.children, (child) => {
         if (this.isReservedChild(child)) {
           children[child.type] = child;
@@ -20,12 +20,12 @@ const ReservedChildren = (ComposedComponent, reservedChildrenTypes) => {
     }
 
     unreservedChildren () {
-      let children = React.Children.toArray(this.props.children);
+      const children = React.Children.toArray(this.props.children);
 
-      return children.filter((child) => !this.isReservedChild(child))
+      return children.filter((child) => !this.isReservedChild(child));
     }
-  }
-}
+  };
+};
 
 
 export default ReservedChildren;

--- a/spec/components/list.jsx
+++ b/spec/components/list.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { ListCheckbox, ListSubHeader, List, ListItem, ListDivider } from '../../components/list';
+import { ListItemLeft, ListItemRight, ListItemCaption, ListItemLegend, ListItemAvatar } from '../../components/list';
 
 const listStyle = {
   border: '1px solid #EEE',
   display: 'inline-block',
+
   minWidth: 340
 };
 
@@ -136,6 +138,28 @@ class ListTest extends React.Component {
             <ListItem caption='Tobias Van Schneider' />
             <ListDivider />
             <ListItem caption='Other people' />
+          </List>
+        </div>
+
+        <h5>Customized list items</h5>
+        <p>Use custom components in the item</p>
+        <div style={listStyle}>
+          <List>
+            <ListItem>
+              <ListItemLeft> <span> left </span> </ListItemLeft>
+              <ListItemAvatar> <img src='https://pbs.twimg.com/profile_images/614407428/s6pTalMzZs-nusCGWqoV.0_400x400.jpeg'/> </ListItemAvatar>
+              <ListItemRight> <span> right </span> </ListItemRight>
+              <ListItemCaption> <span> custom caption </span> </ListItemCaption>
+              <ListItemLegend> <span> custom legend </span> </ListItemLegend> 
+            </ListItem> 
+            <ListItem
+              leftIcon='done'
+              rightIcon='delete'
+              caption='combine'
+              legend='with props'
+              >
+              <ListItemLeft> <span> left </span> </ListItemLeft>
+            </ListItem> 
           </List>
         </div>
       </section>

--- a/spec/components/list.jsx
+++ b/spec/components/list.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ListCheckbox, ListSubHeader, List, ListItem, ListDivider } from '../../components/list';
-import { ListItemLeft, ListItemRight, ListItemCaption, ListItemLegend, ListItemAvatar } from '../../components/list';
+import { ListItemLeft, ListItemRight, ListItemCaption, ListItemLegend, ListItemAvatar, ListItemMiddle } from '../../components/list';
 
 const listStyle = {
   border: '1px solid #EEE',
@@ -148,17 +148,15 @@ class ListTest extends React.Component {
             <ListItem>
               <ListItemLeft> <span> left </span> </ListItemLeft>
               <ListItemAvatar> <img src='https://pbs.twimg.com/profile_images/614407428/s6pTalMzZs-nusCGWqoV.0_400x400.jpeg'/> </ListItemAvatar>
+              <ListItemMiddle>
+                <ListItemCaption> <span> custom caption </span> </ListItemCaption>
+                <ListItemLegend> <span> custom legend </span> </ListItemLegend> 
+              </ListItemMiddle>
               <ListItemRight> <span> right </span> </ListItemRight>
-              <ListItemCaption> <span> custom caption </span> </ListItemCaption>
-              <ListItemLegend> <span> custom legend </span> </ListItemLegend> 
             </ListItem> 
-            <ListItem
-              leftIcon='done'
-              rightIcon='delete'
-              caption='combine'
-              legend='with props'
-              >
+            <ListItem rightIcon='delete' legend='with props'>
               <ListItemLeft> <span> left </span> </ListItemLeft>
+              <ListItemMiddle caption='combine'/>
             </ListItem> 
           </List>
         </div>

--- a/spec/components/list.jsx
+++ b/spec/components/list.jsx
@@ -152,16 +152,16 @@ class ListTest extends React.Component {
               </ListItemAvatar>
               <ListItemMiddle>
                 <ListItemCaption> <span> custom caption </span> </ListItemCaption>
-                <ListItemLegend> <span> custom legend </span> </ListItemLegend> 
+                <ListItemLegend> <span> custom legend </span> </ListItemLegend>
               </ListItemMiddle>
               <ListItemRight> <span> right </span> </ListItemRight>
-            </ListItem> 
+            </ListItem>
             <ListItem rightIcon='delete'>
               <ListItemLeft> <span> left </span> </ListItemLeft>
               <ListItemMiddle caption='combine'>
                 <ListItemLegend> with props </ListItemLegend>
               </ListItemMiddle>
-            </ListItem> 
+            </ListItem>
           </List>
         </div>
       </section>

--- a/spec/components/list.jsx
+++ b/spec/components/list.jsx
@@ -147,16 +147,20 @@ class ListTest extends React.Component {
           <List>
             <ListItem>
               <ListItemLeft> <span> left </span> </ListItemLeft>
-              <ListItemAvatar> <img src='https://pbs.twimg.com/profile_images/614407428/s6pTalMzZs-nusCGWqoV.0_400x400.jpeg'/> </ListItemAvatar>
+              <ListItemAvatar>
+                <img src='https://pbs.twimg.com/profile_images/614407428/s6pTalMzZs-nusCGWqoV.0_400x400.jpeg'/>
+              </ListItemAvatar>
               <ListItemMiddle>
                 <ListItemCaption> <span> custom caption </span> </ListItemCaption>
                 <ListItemLegend> <span> custom legend </span> </ListItemLegend> 
               </ListItemMiddle>
               <ListItemRight> <span> right </span> </ListItemRight>
             </ListItem> 
-            <ListItem rightIcon='delete' legend='with props'>
+            <ListItem rightIcon='delete'>
               <ListItemLeft> <span> left </span> </ListItemLeft>
-              <ListItemMiddle caption='combine'/>
+              <ListItemMiddle caption='combine'>
+                <ListItemLegend> with props </ListItemLegend>
+              </ListItemMiddle>
             </ListItem> 
           </List>
         </div>


### PR DESCRIPTION
I've run multiple times into situation where custom behaviour from either element of the `ListItem` was required. Usually it's either of these:
* use button instead icon
* custom components in the middle part
I had to override `renderContent()` in the `ListItem` to use my desired components and import styles from `react-toolbox`. 

This PR:
* backwards compatible ( passing props to configure `ListItem` )
* uses children to set custom components
* allows overriding `ListItem` components with custom ones
* allows mixings props and custom components for partial overriding
  * custom components have precedence
* solves issue https://github.com/react-toolbox/react-toolbox/issues/92

Example:
```
<List>
  <ListItem>
    <ListItemLeft> <span> left </span> </ListItemLeft>
    <ListItemAvatar>
      <img src='https://pbs.twimg.com/profile_images/614407428/s6pTalMzZs-nusCGWqoV.0_400x400.jpeg'/>
    </ListItemAvatar>
    <ListItemMiddle>
      <ListItemCaption> <span> custom caption </span> </ListItemCaption>
      <ListItemLegend> <span> custom legend </span> </ListItemLegend> 
    </ListItemMiddle>
    <ListItemRight> <span> right </span> </ListItemRight>
  </ListItem> 
  <ListItem rightIcon='delete'>
    <ListItemLeft> <span> left </span> </ListItemLeft>
    <ListItemMiddle caption='combine'>
      <ListItemLegend> with props </ListItemLegend>
    </ListItemMiddle>
  </ListItem> 
</List>
```

![image](https://cloud.githubusercontent.com/assets/1159573/11933803/69b79dfe-a7fe-11e5-939f-67420c9f35b7.png)

Would love your feedback on this!