### PR TITLE
inject ripple into component instead of wrapping it

### DIFF
--- a/components/ripple/AddRippleToComponent.jsx
+++ b/components/ripple/AddRippleToComponent.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import RippleComponent from './RippleComponent';
+
+const AddRippleToComponent = (Component, {centered, className, spread}) => {
+  return class RippledComponent extends Component {
+    static propTypes = {
+      ...Component.propTypes,
+      disabled: React.PropTypes.bool,
+      ripple: React.PropTypes.bool,
+      rippleCentered: React.PropTypes.bool,
+      rippleClassName: React.PropTypes.string,
+      rippleSpread: React.PropTypes.number
+    }
+
+    static defaultProps = {
+      ...Component.defaultProps,
+      ripple: true,
+      rippleCentered: centered,
+      rippleClassName: className,
+      rippleSpread: spread
+    }
+
+    _rippleHandleMouseDown = (event) => {
+      if (!this.props.disabled) {
+        const node = ReactDOM.findDOMNode(this);
+        this.refs.ripple.start(node, event);
+      }
+      if (this.props.onMouseDown) this.props.onMouseDown(event);
+    }
+
+    get _rippleComponent () {
+      const { rippleClassName, rippleCentered, rippleSpread } = this.props;
+
+      return (
+        <RippleComponent {...{rippleClassName, rippleCentered, rippleSpread}} key='ripple_component' ref='ripple' />
+      );
+    }
+
+    render () {
+      const component = super.render();
+      if (this.props.ripple === false) return component;
+
+      const children = [...React.Children.toArray(component.props.children), this._rippleComponent];
+      const props = {onMouseDown: this._rippleHandleMouseDown};
+
+      return React.cloneElement(component, props, children);
+    }
+  };
+};
+
+export default AddRippleToComponent;

--- a/components/ripple/Ripple.jsx
+++ b/components/ripple/Ripple.jsx
@@ -1,8 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import ClassNames from 'classnames';
-import style from './style';
-import prefixer from '../utils/prefixer';
+import StatelessComponent from './StatelessComponent';
+import AddRippleToComponent from './AddRippleToComponent';
 
 const defaults = {
   centered: false,
@@ -11,111 +8,14 @@ const defaults = {
 };
 
 const Ripple = (options = {}) => {
-  const {
-    centered: defaultCentered,
-    className: defaultClassName,
-    spread: defaultSpread
-  } = {...defaults, ...options};
-
   return ComposedComponent => {
-    return class RippledComponent extends React.Component {
-      static propTypes = {
-        children: React.PropTypes.any,
-        disabled: React.PropTypes.bool,
-        ripple: React.PropTypes.bool,
-        rippleCentered: React.PropTypes.bool,
-        rippleClassName: React.PropTypes.string,
-        rippleSpread: React.PropTypes.number
-      };
+    let Component = ComposedComponent;
+    if (ComposedComponent.prototype.render === undefined) {
+       Component = StatelessComponent(ComposedComponent);
+    }
 
-      static defaultProps = {
-        disabled: false,
-        ripple: true,
-        rippleCentered: defaultCentered,
-        rippleClassName: defaultClassName,
-        rippleSpread: defaultSpread
-      };
+    return AddRippleToComponent(Component, {...defaults, ...options});
 
-      state = {
-        active: false,
-        left: null,
-        restarting: false,
-        top: null,
-        width: null
-      };
-
-      handleEnd = () => {
-        document.removeEventListener(this.touch ? 'touchend' : 'mouseup', this.handleEnd);
-        this.setState({active: false});
-      };
-
-      start = ({pageX, pageY}, touch = false) => {
-        if (!this._isTouchRippleReceivingMouseEvent(touch)) {
-          this.touch = touch;
-          document.addEventListener(this.touch ? 'touchend' : 'mouseup', this.handleEnd);
-          const {top, left, width} = this._getDescriptor(pageX, pageY);
-          this.setState({active: false, restarting: true, top, left, width}, () => {
-            this.refs.ripple.offsetWidth;  //eslint-disable-line no-unused-expressions
-            this.setState({active: true, restarting: false});
-          });
-        }
-      };
-
-      _isTouchRippleReceivingMouseEvent (touch) {
-        return this.touch && !touch;
-      }
-
-      _getDescriptor (pageX, pageY) {
-        const {left, top, height, width} = ReactDOM.findDOMNode(this).getBoundingClientRect();
-        const {rippleCentered: centered, rippleSpread: spread} = this.props;
-        return {
-          left: centered ? 0 : pageX - left - width / 2 - window.scrollX,
-          top: centered ? 0 : pageY - top - height / 2 - window.scrollY,
-          width: width * spread
-        };
-      }
-
-      handleMouseDown = (event) => {
-        if (!this.props.disabled) this.start(event);
-        if (this.props.onMouseDown) this.props.onMouseDown(event);
-      };
-
-      render () {
-        if (!this.props.ripple) {
-          return <ComposedComponent {...this.props} />;
-        } else {
-          const {
-            children,
-            ripple,
-            rippleClassName: className,
-            rippleCentered: centered,
-            rippleSpread: spread,
-            ...other
-          } = this.props;
-
-          const rippleClassName = ClassNames(style.normal, {
-            [style.active]: this.state.active,
-            [style.restarting]: this.state.restarting
-          }, className);
-
-          const { left, top, width } = this.state;
-          const scale = this.state.restarting ? 0 : 1;
-          const rippleStyle = prefixer({
-              transform: `translate3d(${-width / 2 + left}px, ${-width / 2 + top}px, 0) scale(${scale})`
-            }, {width, height: width});
-
-
-          return (
-            <ComposedComponent {...other} onMouseDown={this.handleMouseDown}>
-              {children ? children : null}
-              <span data-react-toolbox='ripple' className={style.wrapper}>
-                <span ref='ripple' role='ripple' className={rippleClassName} style={rippleStyle} />
-              </span>
-            </ComposedComponent>
-          );
-        }
-      }
-    };
   };
 };
 

--- a/components/ripple/RippleComponent.jsx
+++ b/components/ripple/RippleComponent.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import ClassNames from 'classnames';
+import style from './style';
+import prefixer from '../utils/prefixer';
+
+class RippleComponent extends React.Component {
+  static propTypes = {
+    rippleCentered: React.PropTypes.bool,
+    rippleClassName: React.PropTypes.string,
+    rippleSpread: React.PropTypes.number
+  };
+
+  state = {
+    active: false,
+    left: null,
+    restarting: false,
+    top: null,
+    width: null
+  };
+
+  handleEnd = () => {
+    document.removeEventListener(this.touch ? 'touchend' : 'mouseup', this.handleEnd);
+    this.setState({active: false});
+  };
+
+  start = (node, {pageX, pageY, touch = false}) => {
+    if (!this._isTouchRippleReceivingMouseEvent(touch)) {
+      this.touch = touch;
+      document.addEventListener(this.touch ? 'touchend' : 'mouseup', this.handleEnd);
+      const {top, left, width} = this._getDescriptor(node, pageX, pageY);
+      this.setState({active: false, restarting: true, top, left, width}, () => {
+        this.refs.ripple.offsetWidth;  //eslint-disable-line no-unused-expressions
+        this.setState({active: true, restarting: false});
+      });
+    }
+  };
+
+  _isTouchRippleReceivingMouseEvent (touch) {
+    return this.touch && !touch;
+  }
+
+  _getDescriptor (node, pageX, pageY) {
+    const {left, top, height, width} = node.getBoundingClientRect();
+    const {rippleCentered: centered, rippleSpread: spread} = this.props;
+
+    return {
+      left: centered ? 0 : pageX - left - width / 2 - window.scrollX,
+      top: centered ? 0 : pageY - top - height / 2 - window.scrollY,
+      width: width * spread
+    };
+  }
+
+  render () {
+    const rippleClassName = ClassNames(style.normal, {
+      [style.active]: this.state.active,
+      [style.restarting]: this.state.restarting
+    }, this.props.rippleClassName);
+
+    const { left, top, width } = this.state;
+    const scale = this.state.restarting ? 0 : 1;
+    const rippleStyle = prefixer({
+      transform: `translate3d(${-width / 2 + left}px, ${-width / 2 + top}px, 0) scale(${scale})`
+    }, {width, height: width});
+
+    return (
+      <span data-react-toolbox='ripple' className={style.wrapper}>
+        <span ref='ripple' role='ripple' className={rippleClassName} style={rippleStyle} />
+      </span>
+    );
+  }
+}
+
+export default RippleComponent;
+

--- a/components/ripple/StatelessComponent.jsx
+++ b/components/ripple/StatelessComponent.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const StatelessComponent = (func) => {
+  return class StatelessComponentWrapper extends React.Component {
+    render () {
+      return func(this.props, this.context, this.updater);
+    }
+  };
+};
+
+export default StatelessComponent;

--- a/spec/components/ripple.jsx
+++ b/spec/components/ripple.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import Ripple from '../../components/ripple';
+
+export default class RippleTest extends React.Component {
+  render () {
+    return (
+      <div>
+        <section>
+          <h5> Adding ripple to components </h5>
+          <div> Ripple set to false: <RippledParent ripple={false}/> </div>
+          <div> Class Component: <RippledParent/> </div>
+          <div> Functional Component: <RippledFunctionalComponent/> </div>
+          <div> Disabled Component: <RippledParent disabled/> </div>
+
+          <h5>Extending Rippled Component</h5>
+          <div> Parent: <Parent/> </div>
+          <div> Child: <Child/> </div>
+          <div> Child of rippled parent: <RippledChild/> </div>
+        </section>
+      </div>
+    );
+  }
+}
+
+
+class Parent extends React.Component{
+  static propTypes = {
+    children: React.PropTypes.array
+  }
+
+  whoami () {
+    return 'I am a parent';
+  }
+
+  render () {
+    return (
+      <span style={{position: 'relative'}}>
+        <span> <b> {this.whoami()} </b> </span>
+        {this.props.children}
+      </span>
+    );
+  }
+}
+
+const RippledParent = Ripple()(Parent);
+
+class RippledChild extends RippledParent {
+  whoami () {
+    return 'I am a rippled child';
+  }
+}
+
+class Child extends Parent {
+  whoami () {
+    return 'I am a child';
+  }
+}
+
+const FunctionalComponent = () => {
+  return <span style={{position: 'relative'}}> <b> I'm a functional component </b> </span>;
+};
+
+const RippledFunctionalComponent = Ripple()(FunctionalComponent);

--- a/spec/root.jsx
+++ b/spec/root.jsx
@@ -24,6 +24,7 @@ import Switch from './components/switch';
 import Table from './components/table';
 import Tabs from './components/tabs';
 import Tooltip from './components/tooltip';
+import Ripple from './components/ripple';
 import style from './style';
 
 const _hrefProject = () => {
@@ -64,6 +65,7 @@ const Root = () => (
     <Table />
     <Tabs />
     <Tooltip />
+    <Ripple />
   </App>
 );
 


### PR DESCRIPTION
POC implementation as follow up to https://github.com/react-toolbox/react-toolbox/issues/228 discussion.

Instead of using HOC for ripple, this patch injects it into children, leaving component class available for extensions.