### PR TITLE
Tooltips works with Link components

### DIFF
--- a/components/link/Link.jsx
+++ b/components/link/Link.jsx
@@ -3,7 +3,7 @@ import ClassNames from 'classnames';
 import style from './style';
 import FontIcon from '../font_icon';
 
-const Link = (props) => {
+const Link = ({children, ...props}) => {
   const className = ClassNames(style.root, {
     [style.active]: props.active
   }, props.className);
@@ -13,12 +13,14 @@ const Link = (props) => {
       {props.icon ? <FontIcon className={style.icon} value={props.icon} /> : null}
       {props.label ? <abbr>{props.label}</abbr> : null}
       {props.count && parseInt(props.count) !== 0 ? <small>{props.count}</small> : null}
+      {children ? children : null}
     </a>
   );
 };
 
 Link.propTypes = {
   active: React.PropTypes.bool,
+  children: React.PropTypes.node,
   className: React.PropTypes.string,
   count: React.PropTypes.number,
   icon: React.PropTypes.string,

--- a/components/link/style.scss
+++ b/components/link/style.scss
@@ -12,7 +12,6 @@
   align-content: center;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
   line-height: 1.5;
   cursor: pointer;
   transition: opacity $animation-duration $animation-curve-default;

--- a/components/tooltip/readme.md
+++ b/components/tooltip/readme.md
@@ -6,14 +6,17 @@ A Tooltip is useful to show information on hover in any kind of component. We ha
 ```jsx
 import Button from 'react-toolbox/lib/button';
 import Tooltip from 'react-toolbox/lib/tooltip';
+import Link from 'react-toolbox/lib/link';
 
 const TooltipButton = Tooltip(Button);
 const TooltipInput = Tooltip(Input);
+const TooltipLink = Tooltip(Link);
 
 const TooltipTest = () => (
   <div>
     <TooltipButton label='Bookmark' icon='bookmark' raised primary tooltip='Bookmark Tooltip' tooltipDelay={1000} />
     <TooltipButton icon='add' floating accent tooltip='Floating Tooltip' />
+    <TooltipLink count={42} href="#" label="The answer is" icon='speaker_notes' tooltip='Question - universe?'/>
     <TooltipInput tooltip='lorem ipsum...' />
   </div>
 );

--- a/docs/app/components/layout/main/modules/examples/tooltip_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/tooltip_example_1.txt
@@ -1,10 +1,12 @@
 const TooltipButton = Tooltip(Button);
 const TooltipInput = Tooltip(Input);
+const TooltipLink = Tooltip(Link);
 
 const TooltipTest = () => (
   <div>
     <TooltipButton label='Bookmark' icon='bookmark' raised primary tooltip='Bookmark Tooltip' tooltipDelay={1000} />
     <TooltipButton icon='add' floating accent tooltip='Floating Tooltip' />
+    <TooltipLink count={42} href="#" label="The answer is" icon='speaker_notes' tooltip='Question - universe?'/>
     <TooltipInput tooltip='lorem ipsum...' />
   </div>
 );

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,7 +34,6 @@
     "html-webpack-plugin": "^1.6.2",
     "markdown-loader": "^0.1.7",
     "node-sass": "^3.3.3",
-    "normalize.css": "^3.0.3",
     "postcss-loader": "^0.7.0",
     "raw-loader": "^0.5.1",
     "react-transform-catch-errors": "^1.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,6 +34,7 @@
     "html-webpack-plugin": "^1.6.2",
     "markdown-loader": "^0.1.7",
     "node-sass": "^3.3.3",
+    "normalize.css": "^3.0.3",
     "postcss-loader": "^0.7.0",
     "raw-loader": "^0.5.1",
     "react-transform-catch-errors": "^1.0.0",


### PR DESCRIPTION
#### Change
I've changed the Link component to render children. I've updated the docs example and component readme to reflect this as well.

#### Note!
* Please review the changes to Link.jsx to see if it's a reasonable way to make the change. I'm new to ES6, not very well versed with how Tooltip renders stuff and also just assumed it would be best to put the children rendering last in the anchor tag. Have some experienced eyes glance over it.
* To make the tooltip visible I removed the `overflow: hidden;` from Link style. Not sure if it's needed fro something else.

Otherwise, seems good,