### PR TITLE
Add a way to detect problems before publish

### DIFF
--- a/.bumpedrc
+++ b/.bumpedrc
@@ -23,9 +23,13 @@ plugins:
       plugin: 'bumped-terminal'
       command: 'git add package.json && git commit package.json -m "$newVersion release" && git push origin master'
 
+    'Detecting problem before publish':
+      plugin: 'bumped-terminal'
+      command: 'git-dirty && npm run clean && rm -rf node_modules && npm install && npm test'
+
     'Publishing tag at Github':
       plugin: 'bumped-terminal'
-      command: 'git tag $newVersion && git push origin $newVersion'
+      command: 'npm run push'
 
     'Publishing at NPM':
       plugin: 'bumped-terminal'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test karma start --no-single-run",
     "release": "bumped release",
-    "patch": "bumped release patch"
+    "patch": "bumped release patch",
+    "push": "git tag $newVersion && git push origin $newVersion"
   },
   "bugs": {
     "url": "https://github.com/react-toolbox/react-toolbox/issues",
@@ -72,6 +73,7 @@
     "expect": "^1.13.4",
     "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.9.1",
+    "git-dirty": "^1.0.0",
     "glob": "^6.0.2",
     "karma": "^0.13.15",
     "karma-chrome-launcher": "^0.2.2",


### PR DESCRIPTION
I create a more safe process to create a new tagged version.

Basically runs [git-dirty](https://github.com/Kikobeats/git-dirty) to check that your local version is sync with remote.

Also I moved some bumped command into npm scripts to be more easy to edit (check push script).

Typically I bind `npm run clean` to `rm -rf node_modules` but you are using the command for other thing so I call rm inline in the bumped command. Consider if is possible merge two actions.