### PR TITLE
Enable any Component to behave as Icon

### DIFF
--- a/components/font_icon/FontIcon.jsx
+++ b/components/font_icon/FontIcon.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import ClassNames from 'classnames';
 
 const FontIcon = ({ children, className, value, ...other}) => {
-  const classes = ClassNames('material-icons', className);
+  const classes = ClassNames(
+    {'material-icons': !React.isValidElement(value)},
+    className
+  );
   return (
     <span className={classes} {...other} >
       {value}
@@ -14,7 +17,7 @@ const FontIcon = ({ children, className, value, ...other}) => {
 FontIcon.propTypes = {
   children: React.PropTypes.any,
   className: React.PropTypes.string,
-  value: React.PropTypes.string
+  value: React.PropTypes.any
 };
 
 FontIcon.defaultProps = {

--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -10,7 +10,7 @@ class Input extends React.Component {
     disabled: React.PropTypes.bool,
     error: React.PropTypes.string,
     floating: React.PropTypes.bool,
-    icon: React.PropTypes.string,
+    icon: React.PropTypes.any,
     label: React.PropTypes.string,
     maxLength: React.PropTypes.number,
     multiline: React.PropTypes.bool,

--- a/spec/components/input.jsx
+++ b/spec/components/input.jsx
@@ -5,7 +5,8 @@ class InputTest extends React.Component {
   state = {
     normal: 'Tony Stark',
     fixedLabel: '',
-    withIcon: ''
+    withIcon: '',
+    withCustomIcon: ''
   };
 
   handleChange = (name, value) => {
@@ -27,6 +28,7 @@ class InputTest extends React.Component {
         <Input type='text' value='Read only' readOnly label='Phone Number' />
         <Input type='text' label='Disabled field' disabled />
         <Input type='tel' value={this.state.withIcon} label='With icon' onChange={this.handleChange.bind(this, 'withIcon')} icon='phone' />
+        <Input type='tel' value={this.state.withCustomIcon} label='With custom icon' onChange={this.handleChange.bind(this, 'withCustomIcon')} icon={<span>A</span>} />
       </section>
     );
   }


### PR DESCRIPTION
Hey there! first of all, thanks for the awesome project you have created. Really enjoying working with it.

I'm wondering what do you think about the following usecase. Sometimes I need icons (social icons for example) that are not in the material-icons set. In those cases, I have to replicate the icon behavior in the outside

eg:
```html
<span>
  <svg.....></svg>
  <Input ..../>
<span>
```

and then of course style that to behave as a native icon.

What if instead of passing the icon as a name, we enable to pass a full react element:
```html
<Input icon={<svg ...></svg>} ... />
```
This way, it will be natively treated as an icon. For the POC I just loosened the validations, from `string` to `any` in the FontIcon and the Input components. If the idea is accepted, I can extend the behavior, and polish it in the whole library.