### PR TITLE
allow passing components to card title and subtitle

### DIFF
--- a/components/card/CardTitle.jsx
+++ b/components/card/CardTitle.jsx
@@ -47,8 +47,14 @@ CardTitle.propTypes = {
     PropTypes.array
   ]),
   className: PropTypes.string,
-  subtitle: PropTypes.string,
-  title: PropTypes.string
+  subtitle: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]),
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ])
 };
 
 export default CardTitle;

--- a/spec/components/card.jsx
+++ b/spec/components/card.jsx
@@ -45,6 +45,21 @@ const cards = {
         </CardActions>
       </Card>
     )
+  }, {
+    name: 'Customized header',
+    component: (
+      <Card className={style.card}>
+        <CardTitle
+          title={<u>Title component</u>}
+          subtitle={<u>Subtitle component</u>}
+        />
+        <CardText>{dummyText}</CardText>
+        <CardActions>
+          <Button label="Action 1" />
+          <Button label="Action 2" />
+        </CardActions>
+      </Card>
+    )
   }],
   media: [{
     name: '16:9 Card Media Area',


### PR DESCRIPTION
We use custom components to provide placeholders. But it could also be used to attach events to title/subtitle.