### PR TITLE
render overlay children on demand only

### DIFF
--- a/components/dialog/Dialog.jsx
+++ b/components/dialog/Dialog.jsx
@@ -15,7 +15,11 @@ const Dialog = (props) => {
   }, props.className);
 
   return (
-    <Overlay active={props.active} onClick={props.onOverlayClick}>
+    <Overlay
+      active={props.active}
+      onClick={props.onOverlayClick}
+      animationDuration={props.animationDuration + props.animationDelay}
+      >
       <div data-react-toolbox='dialog' className={className}>
         <section role='body' className={style.body}>
           {props.title ? <h6 className={style.title}>{props.title}</h6> : null}
@@ -32,6 +36,8 @@ const Dialog = (props) => {
 Dialog.propTypes = {
   actions: React.PropTypes.array,
   active: React.PropTypes.bool,
+  animationDelay: React.PropTypes.number,
+  animationDuration: React.PropTypes.number,
   children: React.PropTypes.node,
   className: React.PropTypes.string,
   onOverlayClick: React.PropTypes.func,
@@ -42,6 +48,8 @@ Dialog.propTypes = {
 Dialog.defaultProps = {
   actions: [],
   active: false,
+  animationDuration: 350,
+  animationDelay: 350 / 5,
   type: 'normal'
 };
 

--- a/components/dialog/style.scss
+++ b/components/dialog/style.scss
@@ -9,15 +9,27 @@
   background-color: $dialog-color-white;
   border-radius: $dialog-border-radius;
   box-shadow: $zdepth-shadow-5;
-  opacity: 0;
+  opacity: 1;
   transition-delay: $animation-delay;
   transition-timing-function: $animation-curve-default;
   transition-duration: $animation-duration;
   transition-property: opacity, transform;
-  transform: translateY(-$dialog-translate-y);
-  &.active {
-    opacity: 1;
-    transform: translateY(0%);
+  transform: translateY(0%);
+}
+
+:global {
+  .rt-overlay-appear, .rt-overlay-leave.rt-overlay-leave-active {
+    :local(.root) {
+      opacity: 0;
+      transform: translateY(-$dialog-translate-y);
+    }
+  }
+
+  .rt-overlay-appear.rt-overlay-appear-active, .rt-overlay-leave {
+    :local(.root) {
+      opacity: 1;
+      transform: translateY(0%);
+    }
   }
 }
 

--- a/components/drawer/Drawer.jsx
+++ b/components/drawer/Drawer.jsx
@@ -4,12 +4,14 @@ import Overlay from '../overlay';
 import style from './style';
 
 const Drawer = (props) => {
-  const className = ClassNames([style.root, style[props.type]], {
-    [style.active]: props.active
-  }, props.className);
+  const className = ClassNames([style.root, style[props.type]], props.className);
 
   return (
-    <Overlay active={props.active} onClick={props.onOverlayClick}>
+    <Overlay
+      active={props.active}
+      onClick={props.onOverlayClick}
+      animationDuration={props.animationDuration + props.animationDelay}
+      >
       <div data-react-toolbox='drawer' className={className}>
         <aside className={style.content}>
           {props.children}
@@ -21,6 +23,8 @@ const Drawer = (props) => {
 
 Drawer.propTypes = {
   active: React.PropTypes.bool,
+  animationDelay: React.PropTypes.number,
+  animationDuration: React.PropTypes.number,
   children: React.PropTypes.node,
   className: React.PropTypes.string,
   onOverlayClick: React.PropTypes.func,
@@ -29,6 +33,8 @@ Drawer.propTypes = {
 
 Drawer.defaultProps = {
   active: false,
+  animationDelay: 350 / 5,
+  animationDuration: 350,
   className: '',
   type: 'left'
 };

--- a/components/drawer/style.scss
+++ b/components/drawer/style.scss
@@ -11,7 +11,7 @@
   overflow-x: hidden;
   overflow-y: auto;
   color: $drawer-text-color;
-  pointer-events: none;
+    pointer-events: all;
   background-color: $drawer-background-color;
   transition-delay: 0s;
   transition-timing-function: $animation-curve-default;
@@ -19,23 +19,34 @@
   transition-property: transform;
   transform-style: preserve-3d;
   will-change: transform;
-  &.active {
-    pointer-events: all;
-    transition-delay: $animation-delay;
-    transform: translateX(0);
-  }
   &.right {
     right: 0;
     border-left: 1px solid $drawer-border-color;
-    &:not(.active) {
-      transform: translateX(100%);
-    }
   }
   &.left {
     left: 0;
     border-right: 1px solid $drawer-border-color;
-    &:not(.active) {
-      transform: translateX(- 100%);
+  }
+}
+
+:global {
+  .rt-overlay-appear, .rt-overlay-leave.rt-overlay-leave-active {
+    :local{
+      .root {
+      &.right {
+        transform: translateX(100%);
+      }
+      &.left {
+        transform: translateX(- 100%);
+      }
+      }
+    }
+  }
+
+  .rt-overlay-appear.rt-overlay-appear-active, .rt-overlay-leave {
+    :local(.root) {
+      transition-delay: $animation-delay;
+      transform: translateX(0);
     }
   }
 }

--- a/components/overlay/Overlay.jsx
+++ b/components/overlay/Overlay.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ClassNames from 'classnames';
 import style from './style';
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 
 class Overlay extends React.Component {
   static propTypes = {
     active: React.PropTypes.bool,
+    animationDuration: React.PropTypes.number,
     children: React.PropTypes.node,
     className: React.PropTypes.string,
     invisible: React.PropTypes.bool,
@@ -13,8 +15,14 @@ class Overlay extends React.Component {
   };
 
   static defaultProps = {
-    invisible: false
+    invisible: false,
+    active: false,
+    animationDuration: 350
   };
+
+  constructor (props) {
+    super(props);
+  }
 
   componentDidMount () {
     this.app = document.querySelector('[data-react-toolbox="app"]') || document.body;
@@ -33,17 +41,36 @@ class Overlay extends React.Component {
     this.app.removeChild(this.node);
   }
 
-  handleRender () {
-    const className = ClassNames(style.root, {
-      [style.active]: this.props.active,
-      [style.invisible]: this.props.invisible
-    }, this.props.className);
-
-    ReactDOM.render(
-      <div className={className}>
-        <div className={style.overlay} onClick={this.props.onClick} />
-        {this.props.children}
+  renderContent () {
+    const {invisible, onClick, children, className} = this.props;
+    const _className = ClassNames(style.root, {[style.invisible]: invisible}, className);
+    return (
+      <div className={_className}>
+        <div className={style.overlay} onClick={onClick} />
+        {children}
       </div>
+    );
+  }
+
+  handleRender () {
+    const {active, animationDuration} = this.props;
+    ReactDOM.render(
+      <ReactCSSTransitionGroup
+        transitionName={{
+          enter: 'rt-overlay-appear',
+          enterActive: 'rt-overlay-appear-active',
+          appear: 'rt-overlay-appear',
+          appearActive: 'rt-overlay-appear-active',
+          leave: 'rt-overlay-leave',
+          leaveActive: 'rt-overlay-leave-active'
+        }}
+        transitionAppear
+        transitionAppearTimeout={animationDuration}
+        transitionLeaveTimeout={animationDuration}
+        transitionEnterTimeout={animationDuration}
+        >
+        {active && this.renderContent()}
+      </ReactCSSTransitionGroup>
     , this.node);
   }
 

--- a/components/overlay/style.scss
+++ b/components/overlay/style.scss
@@ -14,7 +14,15 @@
   align-items: center;
   justify-content: center;
   pointer-events: none;
-  &.invisible > *:not(.overlay) {
+  &.invisible {
+    .overlay {
+      pointer-events: none;
+      //fixme: couldn't make it work with global/local section :(
+      opacity: 0!important;
+    }
+
+  }
+  > * {
     pointer-events: all;
   }
 }
@@ -26,15 +34,22 @@
   width: 100%;
   height: 100%;
   background-color: $overlay-color;
-  opacity: 0;
   transition-timing-function: $animation-curve-default;
   transition-duration: $animation-duration;
   transition-property: opacity;
+  opacity: $overlay-opacity;
 }
 
-.active {
-  pointer-events: all;
-  > .overlay {
-    opacity: $overlay-opacity;
+:global {
+  .rt-overlay-appear, .rt-overlay-leave.rt-overlay-leave-active {
+    :local(.overlay) {
+      opacity: 0;
+    }
+  }
+
+  .rt-overlay-appear.rt-overlay-appear-active, .rt-overlay-leave {
+    :local(.overlay) {
+      opacity: $overlay-opacity;
+    }
   }
 }

--- a/components/snackbar/Snackbar.jsx
+++ b/components/snackbar/Snackbar.jsx
@@ -9,6 +9,8 @@ class Snackbar extends React.Component {
   static propTypes = {
     action: React.PropTypes.string,
     active: React.PropTypes.bool,
+    animationDelay: React.PropTypes.number,
+    animationDuration: React.PropTypes.number,
     className: React.PropTypes.string,
     icon: React.PropTypes.string,
     label: React.PropTypes.string.isRequired,
@@ -16,6 +18,11 @@ class Snackbar extends React.Component {
     onTimeout: React.PropTypes.func,
     timeout: React.PropTypes.number,
     type: React.PropTypes.string
+  };
+
+  static defaultProps = {
+    animationDuration: 350,
+    animationDelay: 350
   };
 
   componentDidUpdate () {
@@ -27,13 +34,11 @@ class Snackbar extends React.Component {
   }
 
   render () {
-    const {action, active, icon, label, onClick, type } = this.props;
-    const className = ClassNames([style.root, style[type]], {
-      [style.active]: active
-    }, this.props.className);
+    const {action, active, icon, label, onClick, type, animationDuration, animationDelay} = this.props;
+    const className = ClassNames([style.root, style[type]], this.props.className);
 
     return (
-      <Overlay invisible>
+      <Overlay active={active} invisible animationDuration={animationDuration + animationDelay}>
         <div data-react-toolbox='snackbar' className={className}>
           {icon ? <FontIcon value={icon} className={style.icon} /> : null}
           <span className={style.label}>{label}</span>

--- a/components/snackbar/style.scss
+++ b/components/snackbar/style.scss
@@ -26,11 +26,19 @@
   &.cancel .button {
     color: $snackbar-color-cancel;
   }
-  &:not(.active) {
-    transform: translateY(100%);
+}
+
+:global {
+  .rt-overlay-appear, .rt-overlay-leave.rt-overlay-leave-active {
+    :local(.root) {
+      transform: translateY(100%);
+    }
   }
-  &.active {
-    transform: translateY(0%);
+
+  .rt-overlay-appear.rt-overlay-appear-active, .rt-overlay-leave {
+    :local(.root) {
+      transform: translateY(0%);
+    }
   }
 }
 


### PR DESCRIPTION
Currently overlay and its children are always in the DOM and change opacity/position on activation.
With this PR overlay renders children only when active. I had to use `ReactCSSTransitionGroup` to keep animation as children don't change active state anymore. `ReactCSSTransitionGroup` is set up to use `:global` styles to give children animation hooks. The drawback of using `ReactCSSTransitionGroup` is necessity to keep animation duration in sync between JS and CSS.

Fixes https://github.com/react-toolbox/react-toolbox/issues/264
