### PR TITLE
allow app-bar height override

### DIFF
--- a/components/app_bar/_config.scss
+++ b/components/app_bar/_config.scss
@@ -1,6 +1,6 @@
 $appbar-color: $color-primary-dark !default;
 $appbar-contrast: $color-primary-contrast !default;
 $appbar-title-total-distance: 8 * $unit;
-$appbar-height: 6.4 * $unit;
+$appbar-height: 6.4 * $unit !default;
 $appbar-h-padding: 2.4 * $unit;
 $appbar-title-distance: $appbar-title-total-distance - $appbar-h-padding;

--- a/spec/style.scss
+++ b/spec/style.scss
@@ -6,7 +6,7 @@ $offset: 1.8 * $unit;
 
 .app {
   @include no-webkit-scrollbar;
-  padding: (8.2 * $unit) $offset $offset;
+  padding: ($appbar-height + 2) $offset $offset;
   background-color: #f5f5f5;
   > section, > div > section {
     padding: $offset;


### PR DESCRIPTION
As mentioned in [Configuring react-toolbox sass variables with toolbox-loader](http://stackoverflow.com/questions/35255862/configuring-react-toolbox-sass-variables-with-toolbox-loader#comment58226733_35256084) there is no possibility to override the height of the app-bar component.

I added the sass `!default` flag and adapted the padding of the app.

