### PR TITLE
Allowing array of pairs key-value as input for autocomplete

### DIFF
--- a/components/autocomplete/Autocomplete.jsx
+++ b/components/autocomplete/Autocomplete.jsx
@@ -120,7 +120,7 @@ class Autocomplete extends React.Component {
  source () {
    const { source: src } = this.props;
    if (src.hasOwnProperty('length')) {
-     return new Map(src.map((item) => [item, item]));
+     return new Map(src.map((item) => Array.isArray(item) ? [...item] : [item, item]));
    } else {
      return new Map(Object.keys(src).map((key) => [key, src[key]]));
    }


### PR DESCRIPTION
I'm having this issue, that I cannot control the order of the sorting in the autocomplete component
Right now the only ways to pass data to autocomplete is `source=['value1', 'value2']` (without keys), or `source={'key1':'value1', 'key2':'value2'}`

the problem is that I have sorted collections where the key is a numeric Id.
```
const collection = [
  [key: 5, value: 'AAA'],
  [key: 1, value: 'ZZZ'],
]
```

when I convert that to a hash, the sorting is lost, and the values presented to the user are in the following order:
```
const source = {
  1: 'ZZZ',
  2: 'AAA'
}
```
With this PR, i'm trying to let the user pass an array of `[key, value]` pairs, so the sorting is not lost. 
Also, as a nice side effect, in this format the key can be a number, which was not possible in the past, as it was converted to a string. Therefore, I can directly match items with whatever value I have in the collection.

Something that i'm not sure I like, is that we will enable another way of passing values to the component: `[value]`, `[key, value]` and `{key: value}`

What do you think?