### PR TITLE
Cleanup listeners on document before unmount

### DIFF
--- a/components/dropdown/Dropdown.jsx
+++ b/components/dropdown/Dropdown.jsx
@@ -43,6 +43,12 @@ class Dropdown extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    if (this.state.active) {
+      events.removeEventsFromDocument({click: this.handleDocumentClick});
+    }
+  }
+
   handleDocumentClick = (event) => {
     if (this.state.active && !events.targetIsDescendant(event, ReactDOM.findDOMNode(this))) {
       this.setState({active: false});

--- a/components/menu/Menu.jsx
+++ b/components/menu/Menu.jsx
@@ -83,6 +83,12 @@ class Menu extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    if (this.state.active) {
+      events.removeEventsFromDocument({click: this.handleDocumentClick});
+    }
+  }
+
   handleDocumentClick = (event) => {
     if (this.state.active && !events.targetIsDescendant(event, ReactDOM.findDOMNode(this))) {
       this.setState({active: false, rippled: false});

--- a/components/slider/Slider.jsx
+++ b/components/slider/Slider.jsx
@@ -55,6 +55,9 @@ class Slider extends React.Component {
 
   componentWillUnmount () {
     window.removeEventListener('resize', this.handleResize);
+    events.removeEventsFromDocument(this.getMouseEventMap());
+    events.removeEventsFromDocument(this.getTouchEventMap());
+    events.removeEventsFromDocument(this.getKeyboardEvents());
   }
 
   handleInputFocus = () => {

--- a/components/time_picker/ClockHand.jsx
+++ b/components/time_picker/ClockHand.jsx
@@ -30,6 +30,11 @@ class Hand extends React.Component {
     this.setState({knobWidth: this.refs.knob.offsetWidth});
   }
 
+  componentWillUnmount () {
+    events.removeEventsFromDocument(this.getMouseEventMap());
+    events.removeEventsFromDocument(this.getTouchEventMap());
+  }
+
   getMouseEventMap () {
     return {
       mousemove: this.handleMouseMove,


### PR DESCRIPTION
If a `Menu` or a `Dropdown` is removed from the DOM while open React throws `Invariant Violation: findDOMNode was called on an unmounted component.` when the next click on the document is intercepted because the listeners are not removed.

I don’t think `Slider`s nor `ClockHand`s throw but there’s still a memory leak as the listeners hold a reference to the component.