### PR TITLE
Move Overlay directly to virtual DOM and fix Dialog overflow

### DIFF
--- a/components/dialog/style.scss
+++ b/components/dialog/style.scss
@@ -43,7 +43,7 @@
 .body {
   flex-grow: 2;
   padding: $dialog-content-padding;
-  overflow-y: auto;
+  overflow-y: visible;
   color: $color-text-secondary;
 }
 

--- a/components/overlay/Overlay.jsx
+++ b/components/overlay/Overlay.jsx
@@ -16,39 +16,18 @@ class Overlay extends React.Component {
     invisible: false
   };
 
-  componentDidMount () {
-    this.app = document.querySelector('[data-react-toolbox="app"]') || document.body;
-    this.node = document.createElement('div');
-    this.node.setAttribute('data-react-toolbox', 'overlay');
-    this.app.appendChild(this.node);
-    this.handleRender();
-  }
-
-  componentDidUpdate () {
-    this.handleRender();
-  }
-
-  componentWillUnmount () {
-    ReactDOM.unmountComponentAtNode(this.node);
-    this.app.removeChild(this.node);
-  }
-
-  handleRender () {
+  render () {
     const className = ClassNames(style.root, {
       [style.active]: this.props.active,
       [style.invisible]: this.props.invisible
     }, this.props.className);
 
-    ReactDOM.render(
+    return (
       <div className={className}>
         <div className={style.overlay} onClick={this.props.onClick} />
         {this.props.children}
       </div>
-    , this.node);
-  }
-
-  render () {
-    return React.DOM.noscript();
+    );
   }
 }
 


### PR DESCRIPTION
We're using react-toolbox with redux, and needed the context a Dialog component. It wasn't available because the Overlay was directly to the DOM, outside the virtual DOM. Moved it back into a regular render() method so we could use redux with Dialog components.

Also, within a dialog component, the Autocomplete component was getting cut off because overflow-y was set to auto. Set overflow-y to visible :)

Thanks!