### PR TITLE
type -> getType as `type` seems to be a keyword in node 5.1

### DIFF
--- a/components/list/ListItemContent.jsx
+++ b/components/list/ListItemContent.jsx
@@ -12,7 +12,7 @@ class ListItemContent extends React.Component {
     type: React.PropTypes.oneOf(types)
   };
 
-  type () {
+  getType () {
     const {type, children, caption, legend} = this.props;
 
     let count = React.Children.count(children);
@@ -25,7 +25,7 @@ class ListItemContent extends React.Component {
   render () {
     const {children, caption, legend} = this.props;
 
-    const className = `${style.itemContentRoot} ${style[this.type()]}`;
+    const className = `${style.itemContentRoot} ${style[this.getType()]}`;
 
     return (
       <span className={className}>


### PR DESCRIPTION
without this, it shows error when starting:
```
ERROR in ./components/list/ListItemContent.jsx
Module build failed: SyntaxError: /home/jackieli/nodejs/react-toolbox/components/list/ListItemContent.jsx: "type" is read-only (This is an error on an internal node. Probably an internal error. Location has been estimated.)
```