### PR TITLE
dropdown accepts string or number as value

### DIFF
--- a/components/dropdown/Dropdown.jsx
+++ b/components/dropdown/Dropdown.jsx
@@ -17,7 +17,10 @@ class Dropdown extends React.Component {
     onFocus: React.PropTypes.func,
     source: React.PropTypes.array.isRequired,
     template: React.PropTypes.func,
-    value: React.PropTypes.string
+    value: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number
+    ])
   };
 
   static defaultProps = {


### PR DESCRIPTION
I couldn't find any reason to restrict the type of the values passed to dropdown to strings. Using integers is common when dealing with ids