### PR TITLE
allow to inject `svg` into `IconButton`

### DIFF
--- a/components/button/IconButton.jsx
+++ b/components/button/IconButton.jsx
@@ -49,10 +49,11 @@ class IconButton extends React.Component {
       'data-react-toolbox': 'button'
     };
 
-    return React.createElement(element, props,
-      icon ? <FontIcon className={style.icon} value={icon}/> : null,
-      children
-    );
+    const iconComp = (typeof icon === 'string') ?
+        <FontIcon className={style.icon} value={icon}/> :
+        (icon || null);
+
+    return React.createElement(element, props, iconComp, children);
   }
 }
 

--- a/spec/components/button.jsx
+++ b/spec/components/button.jsx
@@ -13,6 +13,7 @@ const ButtonTest = () => (
     <Button icon='bookmark' label='Bookmark' accent />
     <Button icon='bookmark' label='Bookmark' raised primary />
     <Button icon='inbox' label='Inbox' flat />
+    <Button icon={<GithubIcon />} label='Github' flat />
     <Button icon='add' floating />
     <Button icon='add' floating primary />
     <Button icon='add' floating primary disabled />
@@ -21,6 +22,7 @@ const ButtonTest = () => (
     <IconButton icon='favorite' inverse />
     <IconButton icon='favorite' />
     <IconButton icon='favorite' disabled />
+    <IconButton icon={<GithubIcon />} />
     <IconButton primary><GithubIcon/></IconButton>
     <Button icon='add' label='Add this' flat primary />
     <Button icon='add' label='Add this' flat disabled />


### PR DESCRIPTION
This enhancement allows to pass in `svg` components into an `IconButton`. The main benefit of this is that this would also work for all components depending on `IconButton` such as `IconMenu` and `MenuItem`.

If you have such an `svg` component:
```JSX
const GithubIcon = () => <svg viewBox="0 0 284 277"> ... </svg>;
```
instead of doing this:
```JSX
<Button href='...' target='_blank' raised>
    <GithubIcon /> Github
</Button>
```
you can now do this:
```JSX
<IconButton icon={<GithubIcon />} label='Github' href='...' target='_blank' raised />
```

But it allows you to use the `Github` `svg` also within an `IconMenu` and `MenuItem` which was not possible before:
```JSX
<IconMenu icon={<GithubIcon />} position='top-left' menuRipple>
    <MenuItem value='download' icon={<GithubIcon />} caption='Github' />
</IconMenu>
```