### PR TITLE
Dropdown doesn't close on click outside fix

### DIFF
--- a/components/dropdown/Dropdown.jsx
+++ b/components/dropdown/Dropdown.jsx
@@ -31,8 +31,8 @@ class Dropdown extends React.Component {
     up: false
   };
 
-  componentWillUpdate (prevState, nextState) {
-    if (!prevState.active && nextState.active) {
+  componentWillUpdate (nextProps, nextState) {
+    if (!this.state.active && nextState.active) {
       events.addEventsToDocument({click: this.handleDocumentClick});
     }
   }

--- a/components/menu/Menu.jsx
+++ b/components/menu/Menu.jsx
@@ -68,8 +68,8 @@ class Menu extends React.Component {
     return true;
   }
 
-  componentWillUpdate (prevState, nextState) {
-    if (!prevState.active && nextState.active) {
+  componentWillUpdate (nextProps, nextState) {
+    if (!this.state.active && nextState.active) {
       events.addEventsToDocument({click: this.handleDocumentClick});
     }
   }


### PR DESCRIPTION
Hi there,

Dropdown component doesn't close on click outside in my app. 
I debugged a little bit problem and found that componentWillUpdate uses incorrect.
It accepts nextProps and nextState and not prevState and nextState
https://facebook.github.io/react/docs/component-specs.html#updating-componentwillupdate