### PR TITLE
Added a few more events to Dialog's overlay

### DIFF
--- a/components/dialog/Dialog.jsx
+++ b/components/dialog/Dialog.jsx
@@ -15,7 +15,13 @@ const Dialog = (props) => {
   }, props.className);
 
   return (
-    <Overlay active={props.active} onClick={props.onOverlayClick}>
+    <Overlay
+      active={props.active}
+      onClick={props.onOverlayClick}
+      onMouseDown={props.onOverlayMouseDown}
+      onMouseUp={props.onOverlayMouseUp}
+      onMouseMove={props.onOverlayMouseMove}
+    >
       <div data-react-toolbox='dialog' className={className}>
         <section role='body' className={style.body}>
           {props.title ? <h6 className={style.title}>{props.title}</h6> : null}
@@ -35,6 +41,9 @@ Dialog.propTypes = {
   children: React.PropTypes.node,
   className: React.PropTypes.string,
   onOverlayClick: React.PropTypes.func,
+  onOverlayMouseDown: React.PropTypes.func,
+  onOverlayMouseUp: React.PropTypes.func,
+  onOverlayMouseMove: React.PropTypes.func,
   title: React.PropTypes.string,
   type: React.PropTypes.string
 };

--- a/components/dialog/readme.md
+++ b/components/dialog/readme.md
@@ -41,5 +41,8 @@ class DialogTest extends React.Component {
 | `actions`       | `Array`         |    `[]`         | A array of objects representing the buttons for the dialog navigation area. The properties will be transferred to the buttons.|
 | `className`     | `String`        |     `''`        | Sets a class to give customized styles to the dialog.|
 | `onOverlayClick`   | `Function`   |             | Callback to be invoked when the dialog overlay is clicked.|
+| `onOverlayMouseDown` | `Function` |             | Callback called when the mouse button is pressed on the overlay. |
+| `onOverlayMouseUp` | `Function` |               | Callback called when the mouse button is released over the overlay. |
+| `onOverlayMouseMove` | `Function` |             | Callback called when the mouse is moving over the overlay. |
 | `title`         | `String`        |                 | The text string to use as standar title of the dialog.|
 | `type`          | `String`        |  `normal`       | Used to determine the size of the dialog. It can be `small`, `normal` or `large`. |


### PR DESCRIPTION
I make an image croper using dialog component, and I need to registrate onMouseUp event on the all visible part of the document, so overlay takes it.  That's why i decided to add a few event to overlay which allow me to complete it. It may be helpful for someone.