### PR TITLE
Change error PropType on Input to node

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -8,7 +8,7 @@ class Input extends React.Component {
     children: React.PropTypes.any,
     className: React.PropTypes.string,
     disabled: React.PropTypes.bool,
-    error: React.PropTypes.string,
+    error: React.PropTypes.node,
     floating: React.PropTypes.bool,
     icon: React.PropTypes.any,
     label: React.PropTypes.string,


### PR DESCRIPTION
We had a weird use case where errors were coming back from the API as HTML.

So to display the errors we did this:

```js
<Input error={
    <span dangerouslySetInnerHTML={{ __html: errors[name] }} />
  }
/>
```

But the error PropType is string, so it was throwing an error. Changed it over to node :)