### PR TITLE
Fix label for number inputs with 0 as value

### DIFF
--- a/components/input/Input.jsx
+++ b/components/input/Input.jsx
@@ -57,9 +57,11 @@ class Input extends React.Component {
       [style.withIcon]: icon
     }, this.props.className);
 
+    const valuePresent = value !== null && value !== undefined && value !== '' && !Number.isNaN(value);
+
     const InputElement = React.createElement(multiline ? 'textarea' : 'input', {
       ...others,
-      className: ClassNames(style.input, {[style.filled]: value}),
+      className: ClassNames(style.input, {[style.filled]: valuePresent}),
       onChange: this.handleChange,
       ref: 'input',
       role: 'input',


### PR DESCRIPTION
For an
`<Input type="number" label="label text" value={0}/>`
the label would overlay the value when it was set to 0 (the integer)
since the checking logic checked for javascript "trueishness".
Now the check is explicit against null, undefined, empty string and NaN.