### PR TITLE
Allows to format the date displayed on datepickers input

### DIFF
--- a/components/date_picker/DatePicker.jsx
+++ b/components/date_picker/DatePicker.jsx
@@ -9,12 +9,12 @@ class DatePicker extends React.Component {
   static propTypes = {
     className: React.PropTypes.string,
     error: React.PropTypes.string,
+    inputFormat: React.PropTypes.func,
     label: React.PropTypes.string,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     onChange: React.PropTypes.func,
-    value: React.PropTypes.object,
-    inputFormat: React.PropTypes.func
+    value: React.PropTypes.object
   };
 
   state = {

--- a/components/date_picker/DatePicker.jsx
+++ b/components/date_picker/DatePicker.jsx
@@ -13,7 +13,8 @@ class DatePicker extends React.Component {
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     onChange: React.PropTypes.func,
-    value: React.PropTypes.object
+    value: React.PropTypes.object,
+    inputFormat: React.PropTypes.func
   };
 
   state = {
@@ -36,7 +37,8 @@ class DatePicker extends React.Component {
 
   render () {
     const { value } = this.props;
-    const date = value ? `${value.getDate()} ${time.getFullMonth(value)} ${value.getFullYear()}` : null;
+    const inputFormat = this.props.inputFormat || time.formatDate;
+    const date = value ? inputFormat(value) : null;
 
     return (
       <div data-react-toolbox='date-picker'>

--- a/components/date_picker/readme.md
+++ b/components/date_picker/readme.md
@@ -23,6 +23,7 @@ class DatePickerTest extends React.Component {
       <section>
         <DatePicker label='Birthdate' onChange={this.handleChange.bind(this, 'date1')} value={this.state.date1} />
         <DatePicker label='Expiration date' minDate={min_datetime} onChange={this.handleChange.bind(this, 'date2')} value={this.state.date2} />
+        <DatePicker label='Formatted date' inputFormat={(value) => `${value.getDate()}/${value.getMonth()}/${value.getFullYear()}`} onChange={this.handleChange.bind(this, 'date3')} value={this.state.date3} />
       </section>
     );
   }
@@ -40,3 +41,4 @@ class DatePickerTest extends React.Component {
 | `onChange`       | `Function`       |                | Callback called when the picker value is changed.|
 | `placeholder`     | `String`        |             | The text string to use like a input placeholder.|
 | `value`         | `Date`    |                 | Date object with the currently selected date. |
+| `inputFormat`         | `Function`    |                 | Function to format the date displayed on the input. |

--- a/components/utils/time.js
+++ b/components/utils/time.js
@@ -179,7 +179,7 @@ const time = {
 
   formatDate (date) {
     return `${date.getDate()} ${time.getFullMonth(date)} ${date.getFullYear()}`;
-  },
+  }
 };
 
 export default time;

--- a/components/utils/time.js
+++ b/components/utils/time.js
@@ -1,4 +1,4 @@
-export default {
+const time = {
   getDaysInMonth (d) {
     const resultDate = this.getFirstDayOfMonth(d);
     resultDate.setMonth(resultDate.getMonth() + 1);
@@ -175,5 +175,11 @@ export default {
 
   dateOutOfRange (date, minDate, maxDate) {
     return ((minDate && !(date >= minDate)) || (maxDate && !(date <= maxDate)));
-  }
+  },
+
+  formatDate (date) {
+    return `${date.getDate()} ${time.getFullMonth(date)} ${date.getFullYear()}`;
+  },
 };
+
+export default time;

--- a/docs/app/components/layout/main/modules/examples/datepicker_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/datepicker_example_1.txt
@@ -26,6 +26,13 @@ class DatePickerTest extends React.Component {
           onChange={this.handleChange.bind(this, 'date2')}
           value={this.state.date2}
         />
+
+        <DatePicker
+          label='Formatted Date'
+          inputFormat={(value) => `${value.getDate()}/${value.getMonth()}/${value.getFullYear()}`}
+          onChange={this.handleChange.bind(this, 'date3')}
+          value={this.state.date3}
+        />
       </section>
     );
   }

--- a/spec/components/pickers.jsx
+++ b/spec/components/pickers.jsx
@@ -41,6 +41,13 @@ class PickersTest extends React.Component {
           value={this.state.date2}
         />
 
+        <DatePicker
+          label='Formatted Date'
+          inputFormat={(value) => `${value.getDate()}/${value.getMonth()}/${value.getFullYear()}`}
+          onChange={this.handleChange.bind(this, 'date3')}
+          value={this.state.date3}
+        />
+
         <TimePicker
           label='Start time'
           onChange={this.handleChange.bind(this, 'time1')}


### PR DESCRIPTION
This allows to display a custom format after selecting a date on the DatePicker. It defaults for the current solution.

It's a first step in order to be able to localize the DatePicker, while I agree that taking a dependency on something such as Intl or moment maybe too much, we can provide some better options such as allowing to format the Dialog display date.