### PR TITLE
Provide own class name to Input of DatePicker

### DIFF
--- a/components/date_picker/DatePicker.jsx
+++ b/components/date_picker/DatePicker.jsx
@@ -41,7 +41,7 @@ class DatePicker extends React.Component {
     return (
       <div data-react-toolbox='date-picker'>
         <Input
-          className={style.input}
+          className={`${style.input} ${this.props.className}`}
           error={this.props.error}
           onMouseDown={this.handleInputMouseDown}
           label={this.props.label}
@@ -51,7 +51,7 @@ class DatePicker extends React.Component {
         />
         <DatePickerDialog
           active={this.state.active}
-          className={this.props.className}
+          className={this.props.dialogClassName}
           maxDate={this.props.maxDate}
           minDate={this.props.minDate}
           onDismiss={this.handleDismiss}

--- a/components/date_picker/DatePicker.jsx
+++ b/components/date_picker/DatePicker.jsx
@@ -41,7 +41,7 @@ class DatePicker extends React.Component {
     return (
       <div data-react-toolbox='date-picker'>
         <Input
-          className={`${style.input} ${this.props.className}`}
+          className={`${style.input} ${this.props.inputClassName}`}
           error={this.props.error}
           onMouseDown={this.handleInputMouseDown}
           label={this.props.label}
@@ -51,7 +51,7 @@ class DatePicker extends React.Component {
         />
         <DatePickerDialog
           active={this.state.active}
-          className={this.props.dialogClassName}
+          className={this.props.className}
           maxDate={this.props.maxDate}
           minDate={this.props.minDate}
           onDismiss={this.handleDismiss}

--- a/components/date_picker/DatePickerDialog.jsx
+++ b/components/date_picker/DatePickerDialog.jsx
@@ -9,6 +9,7 @@ class CalendarDialog extends React.Component {
   static propTypes = {
     active: React.PropTypes.bool,
     className: React.PropTypes.string,
+    inputClassName: React.PropTypes.string,
     maxDate: React.PropTypes.object,
     minDate: React.PropTypes.object,
     onDismiss: React.PropTypes.func,

--- a/components/date_picker/readme.md
+++ b/components/date_picker/readme.md
@@ -33,8 +33,8 @@ class DatePickerTest extends React.Component {
 
 | Name          | Type    | Default         | Description|
 |:-----|:-----|:-----|:-----|
-| `className`         | `String`        |             | This class will be applied to `Input` component of DatePicker. |
-| `dialogClassName` | `String`      |             | This class will be placed at the top of the `DatePickerDialog` component so you can provide custom styles. |
+| `className`         | `String`        |             | This class will be placed at the top of the `DatePickerDialog` component so you can provide custom styles.|
+| `inputClassName` | `String`      |             | This class will be applied to `Input` component of DatePicker. |
 | `label`         | `String`        |             | The text string to use for the floating label element in the input component.|
 | `maxDate`         | `Date`    |                 | Date object with the maximum selectable date. |
 | `minDate`         | `Date`    |                 | Date object with the minimum selectable date. |

--- a/components/date_picker/readme.md
+++ b/components/date_picker/readme.md
@@ -33,7 +33,8 @@ class DatePickerTest extends React.Component {
 
 | Name          | Type    | Default         | Description|
 |:-----|:-----|:-----|:-----|
-| `className`         | `String`        |             | This class will be placed at the top of the `DatePickerDialog` component so you can provide custom styles.|
+| `className`         | `String`        |             | This class will be applied to `Input` component of DatePicker. |
+| `dialogClassName` | `String`      |             | This class will be placed at the top of the `DatePickerDialog` component so you can provide custom styles. |
 | `label`         | `String`        |             | The text string to use for the floating label element in the input component.|
 | `maxDate`         | `Date`    |                 | Date object with the maximum selectable date. |
 | `minDate`         | `Date`    |                 | Date object with the minimum selectable date. |

--- a/components/dialog/readme.md
+++ b/components/dialog/readme.md
@@ -41,5 +41,8 @@ class DialogTest extends React.Component {
 | `actions`       | `Array`         |    `[]`         | A array of objects representing the buttons for the dialog navigation area. The properties will be transferred to the buttons.|
 | `className`     | `String`        |     `''`        | Sets a class to give customized styles to the dialog.|
 | `onOverlayClick`   | `Function`   |             | Callback to be invoked when the dialog overlay is clicked.|
+| `onOverlayMouseDown` | `Function` |             | Callback called when the mouse button is pressed on the overlay. |
+| `onOverlayMouseUp` | `Function` |               | Callback called when the mouse button is released over the overlay. |
+| `onOverlayMouseMove` | `Function` |             | Callback called when the mouse is moving over the overlay. |
 | `title`         | `String`        |                 | The text string to use as standar title of the dialog.|
 | `type`          | `String`        |  `normal`       | Used to determine the size of the dialog. It can be `small`, `normal` or `large`. |


### PR DESCRIPTION
We often want to style the `DatePicker`'s `Input` as other inputs component, but we don't have the possibility to pass its some class name, now we can :)

Firstly I've created a new field in props to pass class name to `DatePickerDialog` and pure `className` provided to `Input` element, but it can break the markup in some projects which already use React-Toolbox. That's why I just created the new field to `Input`'s class name without changes in other parts of `DatePicker` component.