### PR TITLE
Fix #361 cancel timer when tabs component unmounts

### DIFF
--- a/components/tabs/Tabs.jsx
+++ b/components/tabs/Tabs.jsx
@@ -27,6 +27,10 @@ class Tabs extends React.Component {
     this.updatePointer(nextProps.index);
   }
 
+  componentWillUnmount () {
+    clearTimeout(this.pointerTimeout);
+  }
+
   handleHeaderClick = (idx) => {
     if (this.props.onChange) this.props.onChange(idx);
   };
@@ -50,7 +54,8 @@ class Tabs extends React.Component {
   }
 
   updatePointer (idx) {
-    setTimeout(() => {
+    clearTimeout(this.pointerTimeout);
+    this.pointerTimeout = setTimeout(() => {
       const startPoint = this.refs.tabs.getBoundingClientRect().left;
       const label = this.refs.navigation.children[idx].getBoundingClientRect();
       this.setState({


### PR DESCRIPTION
If the component quickly mounts and unmounts, the timers will continue running in the background on a component that isn't in the dom.

Need to clearTimeout before calling another setTimeout to ensure there's only 1 running at any time.

https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html

This fixed #361 #383 