### PR TITLE
feat(ListItem): add className prop support

### DIFF
--- a/components/list/ListItem.jsx
+++ b/components/list/ListItem.jsx
@@ -7,6 +7,7 @@ import style from './style';
 class ListItem extends React.Component {
   static propTypes = {
     children: React.PropTypes.any,
+    className: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     onClick: React.PropTypes.func,
     ripple: React.PropTypes.bool,
@@ -54,9 +55,11 @@ class ListItem extends React.Component {
     const {onMouseDown, to, onClick, ripple, ...other} = this.props;
     const children = this.groupChildren();
     const content = <ListItemLayout {...children} {...other}/>;
+    let className = style.listItem;
+    if (this.props.className) className += ` ${this.props.className}`;
 
     return (
-      <li className={style.listItem} onClick={this.handleClick} onMouseDown={onMouseDown}>
+      <li className={className} onClick={this.handleClick} onMouseDown={onMouseDown}>
         {to ? <a href={this.props.to}>{content}</a> : content}
         {children.ignored}
       </li>


### PR DESCRIPTION
Needed for custom styling of the ListItem (notably if you want to use flex styles to combine it with a MenuItem floating on the right).

Not sure if I have to change something in the specs (the docs seemed to be already OK). We'll gladly update the PR if I have to.