### PR TITLE
Fix #397 Color sass variables missing !default not configurable

### DIFF
--- a/components/autocomplete/_config.scss
+++ b/components/autocomplete/_config.scss
@@ -1,9 +1,9 @@
-$autocomplete-color-primary-contrast: $color-primary-contrast;
-$autocomplete-color-primary: $color-primary;
+$autocomplete-color-primary-contrast: $color-primary-contrast !default;
+$autocomplete-color-primary: $color-primary !default;
 $autocomplete-overflow-max-height: 45vh;
-$autocomplete-suggestion-active-background: $palette-grey-200;
+$autocomplete-suggestion-active-background: $palette-grey-200 !default;
 $autocomplete-suggestion-padding: $unit;
-$autocomplete-suggestions-background: $color-white;
+$autocomplete-suggestions-background: $color-white !default;
 $autocomplete-value-border-radius: .2 * $unit;
 $autocomplete-value-margin: $unit * .25 $unit * .5 $unit * .25 0;
 $autocomplete-value-padding: $unit * .5 $unit * .75;

--- a/components/card/_config.scss
+++ b/components/card/_config.scss
@@ -1,6 +1,6 @@
 $card-color-white: $color-white !default;
 $card-text-overlay: rgba($color-black, 0.35) !default;
-$card-background-color: $card-color-white;
+$card-background-color: $card-color-white !default;
 $card-padding-sm: .8 * $unit;
 $card-padding: 1.6 * $unit;
 $card-padding-lg: 2 * $unit;

--- a/components/date_picker/_config.scss
+++ b/components/date_picker/_config.scss
@@ -1,6 +1,6 @@
-$datepicker-primary: $color-primary;
-$datepicker-primary-contrast: $color-primary-contrast;
-$datepicker-primary-dark: $color-primary-dark;
+$datepicker-primary: $color-primary !default;
+$datepicker-primary-contrast: $color-primary-contrast !default;
+$datepicker-primary-dark: $color-primary-dark !default;
 $datepicker-primary-color: $datepicker-primary !default;
 $datepicker-primary-hover-color: rgba($datepicker-primary, 0.20) !default;
 $datepicker-primary-contrast-color: $datepicker-primary-contrast !default;
@@ -14,8 +14,8 @@ $datepicker-day-font-size: 5 * $unit;
 $datepicker-day-line-height: 4 * $unit;
 $datepicker-year-font-size: $font-size-small;
 
-$calendar-primary: $color-primary;
-$calendar-primary-contrast: $color-primary-contrast;
+$calendar-primary: $color-primary !default;
+$calendar-primary-contrast: $color-primary-contrast !default;
 $calendar-primary-color: $calendar-primary !default;
 $calendar-primary-contrast-color: $calendar-primary-contrast !default;
 $calendar-primary-hover-color: rgba($calendar-primary, 0.21) !default;

--- a/components/dropdown/_config.scss
+++ b/components/dropdown/_config.scss
@@ -1,6 +1,6 @@
-$dropdown-color-white: $color-white;
-$dropdown-color-primary: $color-primary;
-$dropdown-color-primary-contrast: $color-primary-contrast;
-$dropdown-value-hover-background: $palette-grey-200;
+$dropdown-color-white: $color-white !default;
+$dropdown-color-primary: $color-primary !default;
+$dropdown-color-primary-contrast: $color-primary-contrast !default;
+$dropdown-value-hover-background: $palette-grey-200 !default;
 $dropdown-overflow-max-height: 45vh;
 $dropdown-value-border-radius: .2 * $unit;

--- a/components/list/_config.scss
+++ b/components/list/_config.scss
@@ -7,7 +7,7 @@ $list-subheader-font-weight: 500;
 $list-divider-height: .1 * $unit;
 $list-item-min-height: 4.8 * $unit;
 $list-item-min-height-legend: 7.2 * $unit;
-$list-item-hover-color: $palette-grey-200;
+$list-item-hover-color: $palette-grey-200 !default;
 $list-item-legend-margin-top: .3 * $unit;
 $list-item-icon-font-size: 2.4 * $unit;
 $list-item-icon-size: 1.8 * $unit;

--- a/components/menu/_config.scss
+++ b/components/menu/_config.scss
@@ -1,10 +1,10 @@
 $menu-expand-duration: .3s !default;
 $menu-fade-duration: .2s !default;
 $menu-ripple-delay: .3s !default;
-$menu-background-color: $color-white;
+$menu-background-color: $color-white !default;
 $menu-padding: .8 * $unit 0;
 $menu-outline-border-radius: .2 * $unit;
-$menu-item-hover-background: $palette-grey-200;
+$menu-item-hover-background: $palette-grey-200 !default;
 $menu-item-selected-background: transparent !default;
 $menu-item-icon-font-size: 2.4 * $unit;
 $menu-item-icon-size: 1.6 * $menu-item-icon-font-size;

--- a/components/table/_config.scss
+++ b/components/table/_config.scss
@@ -1,5 +1,5 @@
 $table-row-height: 48px;
-$table-row-divider: solid 1px rgba(0,0,0,.12);
+$table-row-divider: solid 1px rgba(0,0,0,.12) !default;
 $table-row-offset: 1.8 * $unit;
-$table-row-highlight: #eee;
-$table-text-color: #757575;
+$table-row-highlight: #eee !default;
+$table-text-color: #757575 !default;

--- a/components/tabs/_config.scss
+++ b/components/tabs/_config.scss
@@ -3,7 +3,7 @@ $tab-label-h-padding: 1.2 * $unit;
 $tab-label-height: 4.8 * $unit;
 $tab-text-height: 1.4 * $unit;
 $tab-label-v-padding: ($tab-label-height - $tab-text-height) / 2;
-$tab-navigation-border-color: $color-divider;
+$tab-navigation-border-color: $color-divider !default;
 $tab-pointer-color: $color-primary !default;
 $tab-pointer-height: .2 * $unit;
 $tab-text: $color-black !default;

--- a/components/time_picker/_config.scss
+++ b/components/time_picker/_config.scss
@@ -1,9 +1,9 @@
 $timepicker-header-font-size: 5.2 * $unit;
 $timepicker-header-padding: $unit;
 $timepicker-ampm-font-size: 1.6 * $unit;
-$timepicker-primary: $color-primary;
-$timepicker-primary-contrast: $color-primary-contrast;
-$timepicker-primary-dark: $color-primary-dark;
+$timepicker-primary: $color-primary !default;
+$timepicker-primary-contrast: $color-primary-contrast !default;
+$timepicker-primary-dark: $color-primary-dark !default;
 $timepicker-primary-color: $timepicker-primary !default;
 $timepicker-primary-hover-color: rgba($timepicker-primary, 0.20) !default;
 $timepicker-primary-contrast-color: $timepicker-primary-contrast !default;
@@ -13,9 +13,9 @@ $timepicker-ampm-width: 4 * $unit;
 $timepicker-dialog-width: 30 * $unit;
 
 $clock-padding: 1.5 * $unit 2 * $unit;
-$clock-primary: $color-primary;
-$clock-primary-contrast: $color-primary-contrast;
-$clock-primary-dark: $color-primary-dark;
+$clock-primary: $color-primary !default;
+$clock-primary-contrast: $color-primary-contrast !default;
+$clock-primary-dark: $color-primary-dark !default;
 $clock-primary-color: $clock-primary !default;
 $clock-primary-hover-color: rgba($clock-primary, 0.20) !default;
 $clock-primary-contrast-color: $clock-primary-contrast !default;


### PR DESCRIPTION
Add default statements to color variables, which is necessary for them to be configurable via toolbox-loader.