### PR TITLE
Renders Selected Item when multiple=false

### DIFF
--- a/components/autocomplete/Autocomplete.jsx
+++ b/components/autocomplete/Autocomplete.jsx
@@ -110,7 +110,8 @@ class Autocomplete extends React.Component {
    const query = this.state.query.toLowerCase().trim() || '';
    const values = this.values();
    for (const [key, value] of this.source()) {
-     if (!values.has(key) && value.toLowerCase().trim().startsWith(query)) {
+     if (value.toLowerCase().trim().startsWith(query) &&
+         (!values.has(key) || !this.props.multiple)) {
        suggest.set(key, value);
      }
    }


### PR DESCRIPTION
Related #252 

This commit will render the selected value only when autocomplete has multiple=false. I noticed this was missing and I think its a good to have feature. Also when the filters the list to a single item, the suggestions will still be rendered so they can click on that, making it a better user experience.

If there's anything you would like me to consider or fix, please let me know and I'll work on it ASAP.