### PR TITLE
Fixed Object Single Selection Bug

### DIFF
--- a/components/autocomplete/Autocomplete.jsx
+++ b/components/autocomplete/Autocomplete.jsx
@@ -39,7 +39,7 @@ class Autocomplete extends React.Component {
 
  componentWillReceiveProps (nextProps) {
    if (!this.props.multiple) {
-     this.setState({query: nextProps.value});
+     this.setState({query: this.query(nextProps.value)});
    }
  }
 

--- a/spec/components/autocomplete.jsx
+++ b/spec/components/autocomplete.jsx
@@ -33,9 +33,9 @@ class AutocompleteTest extends React.Component {
 
         <Autocomplete
           label="Choose a country"
+          hint="Elements up to you..."
           multiple={false}
           onChange={this.handleSimpleChange}
-          placeholder="Elements up to you..."
           source={countriesArray}
           value={this.state.simple}
         />


### PR DESCRIPTION
Fixes #354 

Added a check on cwrp handler to retrieve the query value if the multiple is false. This made the query state to be set as the value instead of the key so the value will be rendered and the key can be stored.