### PR TITLE
Updated Babel Standalone to latest version

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "deploy": "gh-pages -d build"
   },
   "dependencies": {
-    "babel-standalone": "^1.0.0",
+    "babel-standalone": "^6.7.4",
     "classnames": "^2.2.1",
     "codemirror": "^5.10.0",
     "history": "^1.17.0",


### PR DESCRIPTION
Fixes #124 

When I logged the error in the console, the babel plugin used to transpile the code from ES6 to ES5 was giving an error. Updating the plugin fixed this issue.