### PR TITLE
Fix Snackbar timeout issue

### DIFF
--- a/components/snackbar/Snackbar.jsx
+++ b/components/snackbar/Snackbar.jsx
@@ -18,11 +18,24 @@ class Snackbar extends React.Component {
     type: React.PropTypes.string
   };
 
-  componentDidUpdate () {
-    if (this.props.active && this.props.timeout) {
-      setTimeout(() => {
-        this.props.onTimeout();
-      }, this.props.timeout);
+  state = {
+    curTimeout: null
+  };
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.active && nextProps.timeout) {
+      if(this.state.curTimeout) clearTimeout(this.state.curTimeout);
+
+      let curTimeout = setTimeout(() => {
+        nextProps.onTimeout();
+        this.setState({
+          curTimeout: null
+        });
+      }, nextProps.timeout);
+
+      this.setState({
+        curTimeout
+      });
     }
   }
 

--- a/components/snackbar/Snackbar.jsx
+++ b/components/snackbar/Snackbar.jsx
@@ -24,9 +24,9 @@ class Snackbar extends React.Component {
 
   componentWillReceiveProps (nextProps) {
     if (nextProps.active && nextProps.timeout) {
-      if(this.state.curTimeout) clearTimeout(this.state.curTimeout);
+      if (this.state.curTimeout) clearTimeout(this.state.curTimeout);
 
-      let curTimeout = setTimeout(() => {
+      const curTimeout = setTimeout(() => {
         nextProps.onTimeout();
         this.setState({
           curTimeout: null


### PR DESCRIPTION
This change now wipes previous timeouts when the Snackbar is reactivated

Steps to reproduce the issue:
1) Activate a Snackbar by clicking its Activation Button
2) Reactivate the Snackbar before its timeout activates by either:
    2A) Reactivating the Snackbar by clicking its Activation Button again
    2B) Dismiss the Snackbar via its Dismissal Button, and then click the Activation Button again
3) Observe that the initial timeout will still effect the new activation of the Snackbar