### PR TITLE
Tabs: ability to (optionally) reference by key instead of index

### DIFF
--- a/components/tabs/Tabs.jsx
+++ b/components/tabs/Tabs.jsx
@@ -9,6 +9,7 @@ class Tabs extends React.Component {
     className: React.PropTypes.string,
     disableAnimatedBottomBorder: React.PropTypes.bool,
     index: React.PropTypes.number,
+    tab: React.PropTypes.string,
     onChange: React.PropTypes.func
   };
 
@@ -22,12 +23,12 @@ class Tabs extends React.Component {
 
   componentDidMount () {
     !this.props.disableAnimatedBottomBorder &&
-      this.updatePointer(this.props.index);
+      this.updatePointer(this.props.index, this.props);
   }
 
   componentWillReceiveProps (nextProps) {
     !this.props.disableAnimatedBottomBorder &&
-      this.updatePointer(nextProps.index);
+      this.updatePointer(nextProps.index, nextProps);
   }
 
   componentWillUnmount () {
@@ -35,7 +36,8 @@ class Tabs extends React.Component {
   }
 
   handleHeaderClick = (idx) => {
-    if (this.props.onChange) this.props.onChange(idx);
+    if (this.props.onChange)
+      this.props.onChange(idx, this.props.children[idx].key);
   };
 
   parseChildren () {
@@ -46,7 +48,7 @@ class Tabs extends React.Component {
       if (item.type === Tab) {
         headers.push(item);
         if (item.props.children) {
-          contents.push(<TabContent children={item.props.children}/>);
+          contents.push(<TabContent key={item.key} children={item.props.children}/>);
         }
       } else if (item.type === TabContent) {
         contents.push(item);
@@ -56,7 +58,10 @@ class Tabs extends React.Component {
     return {headers, contents};
   }
 
-  updatePointer (idx) {
+  updatePointer (idx, props) {
+    if (props.tab)
+      idx = props.children.findIndex(c => c.key === props.tab);
+
     clearTimeout(this.pointerTimeout);
     this.pointerTimeout = setTimeout(() => {
       const startPoint = this.refs.tabs.getBoundingClientRect().left;
@@ -74,8 +79,10 @@ class Tabs extends React.Component {
   renderHeaders (headers) {
     return headers.map((item, idx) => {
       return React.cloneElement(item, {
-        key: idx,
-        active: this.props.index === idx,
+        key: item.key || idx,
+        active: this.props.tab
+          ? this.props.tab === item.key
+          : this.props.index === idx,
         onClick: this.handleHeaderClick.bind(this, idx, item)
       });
     });
@@ -83,11 +90,13 @@ class Tabs extends React.Component {
 
   renderContents (contents) {
     var idx = contents.findIndex((item, idx) => {
-      return this.props.index === idx;
+      return this.props.tab
+        ? this.props.tab === item.key
+        : this.props.index === idx;
     });
 
     return React.cloneElement(contents[idx], {
-      key: idx,
+      key: contents[idx].key || idx,
       active: true,
       tabIndex: idx
     });

--- a/components/tabs/Tabs.jsx
+++ b/components/tabs/Tabs.jsx
@@ -82,12 +82,14 @@ class Tabs extends React.Component {
   }
 
   renderContents (contents) {
-    return contents.map((item, idx) => {
-      return React.cloneElement(item, {
-        key: idx,
-        active: this.props.index === idx,
-        tabIndex: idx
-      });
+    var idx = contents.findIndex((item, idx) => {
+      return this.props.index === idx;
+    });
+
+    return React.cloneElement(contents[idx], {
+      key: idx,
+      active: true,
+      tabIndex: idx
     });
   }
 


### PR DESCRIPTION
Hey, this draft PR allows tabs to specify their own key and choose the active tab - optionally - by name instead of the index.  Example usage: the key name is used as part of routing structure; consistent names even when re-ordering tabs; etc.

```jsx
<Tabs tab="fruit">
  <Tab key="fruit" label="Fruit">...</Tab>
</Tabs>
```

This also adds an extra parameter to the callback:

```js
onChange(index, keyNameIfItExists)
```

If you're happy with the idea, I can see if I can make the code any cleaner, add tests, documentation, etc.