### PR TITLE
docs(media): keep navigation open with playground for wider screens

### DIFF
--- a/docs/app/components/layout/main/_config.scss
+++ b/docs/app/components/layout/main/_config.scss
@@ -1,5 +1,7 @@
 @import "../../globals";
 
+$media-min-width: 1440px;
+$playground-max-width: $media-min-width / 2;
 $playground-width: 50%;
 $navigation-width: 22 * $unit;
 $navigation-h-padding: 2.4 * $unit;

--- a/docs/app/components/layout/main/style.scss
+++ b/docs/app/components/layout/main/style.scss
@@ -80,3 +80,20 @@ hr {
 .load-button {
   display: inline-block;
 }
+
+@media(min-width: $media-min-width) {
+  .root {
+    .playground {
+      width: $playground-max-width;
+    }
+    &.with-playground {
+      > .documentation {
+        padding-right: $playground-max-width;
+        padding-left: $navigation-width;
+      }
+      > .navigation {
+        transform: translateX(0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
The navigation in the docs is a bit painful when you want to quickly play with components in the playground. Having the navigation bar hidden every time you show the playground is burdensome. This fix keeps the navigation open when you have a screen wider than 1440px.

Wanted to automatically switch the playground when you navigate, but encountered issues with `react-router@v1` and mixins+ES6. Could try to upgrade react-router if you want.