### PR TITLE
have Dialog.jsx import from './style' and not './style.scss'

### DIFF
--- a/components/dialog/Dialog.jsx
+++ b/components/dialog/Dialog.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ClassNames from 'classnames';
 import Button from '../button';
 import Overlay from '../overlay';
-import style from './style.scss';
+import style from './style';
 
 const Dialog = (props) => {
   const actions = props.actions.map((action, idx) => {


### PR DESCRIPTION
This brings the import in line with other components, and fixes sensitive bundlers that rely on this (i.e. the current early way we're doing it in Meteor).