### PR TITLE
Don't show actions container in dialog if no actions exist

### DIFF
--- a/components/dialog/Dialog.jsx
+++ b/components/dialog/Dialog.jsx
@@ -28,9 +28,12 @@ const Dialog = (props) => {
           {props.title ? <h6 className={style.title}>{props.title}</h6> : null}
           {props.children}
         </section>
-        <nav role='navigation' className={style.navigation}>
-          {actions}
-        </nav>
+        {actions ?
+          <nav role='navigation' className={style.navigation}>
+            {actions}
+          </nav> :
+          null
+        }
       </div>
     </Overlay>
   );


### PR DESCRIPTION
This PR makes sure that the navigation container of the dialog component isn't shown if no actions exist.

This way we also don't get the (default 0.8em) padded bottom if there's no actions.