### PR TITLE
Add allowBlank to Dropdown

### DIFF
--- a/components/dropdown/Dropdown.jsx
+++ b/components/dropdown/Dropdown.jsx
@@ -7,6 +7,7 @@ import style from './style';
 
 class Dropdown extends React.Component {
   static propTypes = {
+    allowBlank: React.PropTypes.bool,
     auto: React.PropTypes.bool,
     className: React.PropTypes.string,
     disabled: React.PropTypes.bool,
@@ -26,6 +27,7 @@ class Dropdown extends React.Component {
   static defaultProps = {
     auto: true,
     className: '',
+    allowBlank: true,
     disabled: false
   };
 
@@ -50,11 +52,6 @@ class Dropdown extends React.Component {
     if (this.state.active) {
       events.removeEventsFromDocument({click: this.handleDocumentClick});
     }
-  }
-
-  valueIsPresent () {
-    const value = this.props.value;
-    return value !== null && value !== undefined && value !== '' && !Number.isNaN(value);
   }
 
   close = () => {
@@ -87,10 +84,11 @@ class Dropdown extends React.Component {
   };
 
   getSelectedItem = () => {
-    if (this.valueIsPresent()) {
-      for (const item of this.props.source) {
-        if (item.value === this.props.value) return item;
-      }
+    for (const item of this.props.source) {
+      if (item.value === this.props.value) return item;
+    }
+    if (!this.props.allowBlank) {
+      return this.props.source[0];
     }
   };
 

--- a/components/dropdown/readme.md
+++ b/components/dropdown/readme.md
@@ -48,3 +48,4 @@ class DropdownTest extends React.Component {
 | `source`    | `Array`         |                 | Array of data objects with the data to represent in the dropdown.
 | `template`      | `Function`      |                 | Callback function that returns a JSX template to represent the element.
 | `value`         | `String`        |                 | Default value using JSON data.
+| `allowBlank`    | `Boolean`       | `true`            | If true the dropdown will preselect the first item if the supplied value matches none of the options' values


### PR DESCRIPTION
Since @nickw was having issues with the dropdown not defaulting to the
first entry if the value was null (even though the options had a null value in it)
this seems like a good time to add an option to default to the first element of the supplied options
(the prop is called allowBlank) in case the value is not found in the options.

The handling of null/undefined values has been fixed too and if there actually is a value of null
in the options it is correctly selected now.