### PR TITLE
Revert input error color

### DIFF
--- a/components/input/_config.scss
+++ b/components/input/_config.scss
@@ -10,7 +10,7 @@ $input-text-bottom-border-color: rgba($color-black, 0.12) !default;
 $input-text-highlight-color: $color-primary !default;
 $input-text-disabled-color: $input-text-bottom-border-color !default;
 $input-text-disabled-text-color: $input-text-label-color !default;
-$input-text-error-color: rgb(222, 230, 38) !default;
+$input-text-error-color: rgb(222, 50, 38) !default;
 $input-text-required-color: rgb(222, 50, 38) !default;
 $input-underline-height:  2 * $unit;
 $input-icon-font-size: 2.4 * $unit;


### PR DESCRIPTION
PR #379 (unintentionally, I assume) changed the default error color for inputs to yellow:

![unexpected input error color](https://i.gyazo.com/a3c2be8411412991e06fb6d4ac7a6972.png)