### PR TITLE
issue: 448 body scroll in HOC Portal.js

### DIFF
--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -68,7 +68,7 @@ class Portal extends Component {
 
   _unrenderOverlay () {
     if (this._overlayTarget) {
-      if (this.props.lockBody) document.body.style.overflow = 'scroll';
+      if (this.props.lockBody) document.body.style.overflow = 'auto';
       ReactDOM.unmountComponentAtNode(this._overlayTarget);
       this._overlayInstance = null;
     }

--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -68,7 +68,7 @@ class Portal extends Component {
 
   _unrenderOverlay () {
     if (this._overlayTarget) {
-      if (this.props.lockBody) document.body.style.overflow = 'auto';
+      if (this.props.lockBody) document.body.style.overflow = null;
       ReactDOM.unmountComponentAtNode(this._overlayTarget);
       this._overlayInstance = null;
     }


### PR DESCRIPTION
Submitting a PR to fix issue #448 where document.body.style.overflow was set to scroll, causing a horizontal scroll bar to appear unnecessarily. Changing the value to auto does not fix the issue. Because 'auto' is still an inline style, it will also override any CSS styles on the body (such as overflow-x: hidden). We should allow developers to handle the CSS styles on the body as they desire. This can be accomplished by setting document.body.style.overflow = null (which removes it from the DOM) if toolbox does not have an explicit need to scroll.