### PR TITLE
Changed Autocomplete working logic (only multiple=false).

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -6,6 +6,8 @@ import events from '../utils/events';
 import Chip from '../chip';
 import style from './style';
 
+console.log(111);
+
 const POSITION = {
  AUTO: 'auto',
  DOWN: 'down',


### PR DESCRIPTION
Problem: if item selected and user focus Input there is only one item appears in droplist that matched to this query. It's bad bcs I'd like to select other item and I need to remove selected item first..
Solution: I added 'changed' param that checking if query changed, when user focusing Input 'changed' param's value is false and there are all items except selected in the droplist, after user changes query 'changed' param sets to true and this.suggestions return matched items.