### PR TITLE
re #448: add / remove noScroll class instead of settig inline style directly

### DIFF
--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
+import style from './style';
 
 class Portal extends Component {
   static propTypes = {
@@ -55,7 +56,7 @@ class Portal extends Component {
       : React.Children.only(this.props.children);
 
     if (overlay !== null) {
-      if (this.props.lockBody) document.body.style.overflow = 'hidden';
+      if (this.props.lockBody) document.body.classList.add(style.noScroll);
       this._mountOverlayTarget();
       this._overlayInstance = ReactDOM.unstable_renderSubtreeIntoContainer(
         this, overlay, this._overlayTarget
@@ -68,7 +69,7 @@ class Portal extends Component {
 
   _unrenderOverlay () {
     if (this._overlayTarget) {
-      if (this.props.lockBody) document.body.style.overflow = 'scroll';
+      if (this.props.lockBody) document.body.classList.remove(style.noScroll);
       ReactDOM.unmountComponentAtNode(this._overlayTarget);
       this._overlayInstance = null;
     }

--- a/components/hoc/style.scss
+++ b/components/hoc/style.scss
@@ -1,0 +1,3 @@
+.noScroll {
+  overflow: hidden;
+}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mocha": "^2.3.4",
     "node-sass": "^3.4.2",
     "normalize.css": "^4.0.0",
-    "phantomjs": "^2.1.7",
+    "phantomjs-prebuilt": "^2.1.7",
     "phantomjs-polyfill": "0.0.2",
     "postcss-loader": "^0.8.2",
     "react": "^15.0.1",


### PR DESCRIPTION
This has conflicts as I forked my branch from `master` to run our own tests on the stable codebase. If you approve the idea I will rebase it against `dev`.

I've also renamed the phantom dependency name to suppress the warning.