### PR TITLE
Fix DatePickerDialog to correctly display the previously selected date

### DIFF
--- a/components/date_picker/DatePickerDialog.js
+++ b/components/date_picker/DatePickerDialog.js
@@ -24,9 +24,18 @@ class CalendarDialog extends React.Component {
   };
 
   state = {
-    date: this.props.value,
-    display: 'months'
+    display: 'months',
+    date: this.props.value
   };
+
+  componentWillMount () {
+    this.updateStateDate(this.props.value);
+
+  }
+
+  componentWillReceiveProps (nextProps) {
+    this.updateStateDate(nextProps.value);
+  }
 
   handleCalendarChange = (value, dayClick) => {
     const state = {display: 'months', date: value};
@@ -46,6 +55,14 @@ class CalendarDialog extends React.Component {
   handleSwitchDisplay = (display) => {
     this.setState({ display });
   };
+
+  updateStateDate = (date) => {
+    if (Object.prototype.toString.call(date) === '[object Date]') {
+      this.setState({
+        date
+      });
+    }
+  }
 
   actions = [
     { label: 'Cancel', className: style.button, onClick: this.props.onDismiss },


### PR DESCRIPTION
This fixed issue #445

The calendar was displaying todays date every time it was opened, rather than the date contained in the input field.