### PR TITLE
Fix for jspm

### DIFF
--- a/components/animations/style.js
+++ b/components/animations/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/animations/style.js
+++ b/components/animations/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/app_bar/style.js
+++ b/components/app_bar/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/app_bar/style.js
+++ b/components/app_bar/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/autocomplete/style.js
+++ b/components/autocomplete/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/autocomplete/style.js
+++ b/components/autocomplete/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/avatar/style.js
+++ b/components/avatar/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/avatar/style.js
+++ b/components/avatar/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/button/style.js
+++ b/components/button/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/button/style.js
+++ b/components/button/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/card/style.js
+++ b/components/card/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/card/style.js
+++ b/components/card/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/checkbox/style.js
+++ b/components/checkbox/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/checkbox/style.js
+++ b/components/checkbox/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/chip/style.js
+++ b/components/chip/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/chip/style.js
+++ b/components/chip/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/date_picker/style.js
+++ b/components/date_picker/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/date_picker/style.js
+++ b/components/date_picker/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/dialog/style.js
+++ b/components/dialog/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/dialog/style.js
+++ b/components/dialog/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/drawer/style.js
+++ b/components/drawer/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/drawer/style.js
+++ b/components/drawer/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/dropdown/style.js
+++ b/components/dropdown/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/dropdown/style.js
+++ b/components/dropdown/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/font_icon/style.js
+++ b/components/font_icon/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/font_icon/style.js
+++ b/components/font_icon/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/form/style.js
+++ b/components/form/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/form/style.js
+++ b/components/form/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/hoc/style.js
+++ b/components/hoc/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/hoc/style.js
+++ b/components/hoc/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/input/style.js
+++ b/components/input/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/input/style.js
+++ b/components/input/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/layout/style.js
+++ b/components/layout/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/layout/style.js
+++ b/components/layout/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/link/style.js
+++ b/components/link/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/link/style.js
+++ b/components/link/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/list/style.js
+++ b/components/list/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/list/style.js
+++ b/components/list/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/menu/style.js
+++ b/components/menu/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/menu/style.js
+++ b/components/menu/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/navigation/style.js
+++ b/components/navigation/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/navigation/style.js
+++ b/components/navigation/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/overlay/style.js
+++ b/components/overlay/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/overlay/style.js
+++ b/components/overlay/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/progress_bar/style.js
+++ b/components/progress_bar/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/progress_bar/style.js
+++ b/components/progress_bar/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/radio/style.js
+++ b/components/radio/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/radio/style.js
+++ b/components/radio/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/ripple/style.js
+++ b/components/ripple/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/ripple/style.js
+++ b/components/ripple/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/slider/style.js
+++ b/components/slider/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/slider/style.js
+++ b/components/slider/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/snackbar/style.js
+++ b/components/snackbar/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/snackbar/style.js
+++ b/components/snackbar/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/switch/style.js
+++ b/components/switch/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/switch/style.js
+++ b/components/switch/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/table/style.js
+++ b/components/table/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/table/style.js
+++ b/components/table/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/tabs/style.js
+++ b/components/tabs/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/tabs/style.js
+++ b/components/tabs/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/time_picker/style.js
+++ b/components/time_picker/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/time_picker/style.js
+++ b/components/time_picker/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/tooltip/style.js
+++ b/components/tooltip/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/tooltip/style.js
+++ b/components/tooltip/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';

--- a/components/utils/style.js
+++ b/components/utils/style.js
@@ -1,0 +1,1 @@
+import './style.scss!';

--- a/components/utils/style.js
+++ b/components/utils/style.js
@@ -1,1 +1,1 @@
-import './style.scss!';
+import './style.scss!sass';


### PR DESCRIPTION
#82 

jspm load non js files with special loaders. For sass, it uses [plugin-sass](https://github.com/mobilexag/plugin-sass).
These special loaders are invoked by the presence of the `!` character, like this : `import './style.scss!';`.

Without this, jspm expects a simple .js file, therefore, it raises exceptions when it fails to import `style.js`.
To resolve this issue, I simply added a `style.js` file that load the corresponding scss file in each components directory.

As the files holds the scss extension, jspm would look for a scss module, not a sass module.
To correct this, sass needs to be specified at the end of the import, like this : 

```
import './style.scss!sass';
```
These files are then compiled and put directly into the lib folder.
And apparently it works :)