### PR TITLE
Fix #454: Chip component unable to display nicely on small screen

### DIFF
--- a/components/chip/style.scss
+++ b/components/chip/style.scss
@@ -3,12 +3,17 @@
 @import "./config";
 
 .chip {
+  position: relative;
   display: inline-block;
+  max-width: 100%;
   padding: 0 $chip-padding;
   margin-right: $chip-margin-right;
+  overflow: hidden;
   font-size: $chip-font-size;
   line-height: $chip-height;
   color: $chip-color;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   background-color: $chip-background;
   border-radius: $chip-height;
 }
@@ -35,6 +40,7 @@
 
 .delete {
   position: absolute;
+  right: 0;
   display: inline-block;
   width: $chip-remove-size;
   height: $chip-remove-size;

--- a/spec/components/chip.js
+++ b/spec/components/chip.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Avatar from '../../components/avatar';
 import Chip from '../../components/chip';
+import style from '../style';
 
 class ChipTest extends React.Component {
   state = {
@@ -49,6 +50,13 @@ class ChipTest extends React.Component {
           <Avatar><img src="https://placeimg.com/80/80/animals"/></Avatar>
           <span>Image contact chip</span>
         </Chip>
+
+        <div className={style.chipTruncateWrapper}>
+          <Chip deletable>
+            Truncated chip with long label. Lorem ipsum Amet quis mollit Excepteur id dolore.
+          </Chip>
+        </div>
+
       </section>
     );
   }

--- a/spec/style.scss
+++ b/spec/style.scss
@@ -112,6 +112,13 @@ $offset: 1.8 * $unit;
   width: 345px;
 }
 
+.chipTruncateWrapper {
+  width: 20rem;
+  padding: $offset / 2;
+  margin-top: $offset;
+  border: 1px solid #f4f4f4;
+}
+
 .dropdownTemplate {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Added text truncation to chip component and limit its size to the the size of the containing element.

![screen shot 2016-04-27 at 11 53 52](https://cloud.githubusercontent.com/assets/186534/14848601/c65a55f4-0c6e-11e6-8210-c814229f9b42.png)

Fixes #454: Chip component unable to display nicely on small screen