### PR TITLE
Fix #481: Body text line height is too large

### DIFF
--- a/components/_mixins.scss
+++ b/components/_mixins.scss
@@ -120,7 +120,7 @@
   @include typo-preferred-font($use-preferred);
   font-size: 1.4rem;
   font-weight: 400;
-  line-height: 2.4rem;
+  line-height: 2rem;
   letter-spacing: 0;
 
   @if $color-contrast {


### PR DESCRIPTION
Adjust body text line height to conform to material design spec, fixes #481.

The [spec](https://www.google.com/design/spec/style/typography.html#typography-line-height) specifies the leading as 20pt, which should correspond to a line height of 2.0rem in react-toolbox.

Please note that this change may have unwanted side effects as sizes of paragraph elements will change. I have not tested the implications on all components.
