### PR TITLE
Autocomplete element size

### DIFF
--- a/components/autocomplete/style.scss
+++ b/components/autocomplete/style.scss
@@ -56,6 +56,7 @@
 
 .suggestion {
   padding: $autocomplete-suggestion-padding;
+  font-size: $input-field-font-size;
   cursor: pointer;
   &.active {
     background-color: $autocomplete-suggestion-active-background;


### PR DESCRIPTION
Suggestion element will render font size based on body size, so these elements getting to small. 
This change will make suggestion element to be consistent size of other elements.