### PR TITLE
Hotfix for incorrect ternary statement in DatePicker

### DIFF
--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -45,7 +45,7 @@ class DatePicker extends React.Component {
     const { inputClassName, value } = this.props;
     const inputFormat = this.props.inputFormat || time.formatDate;
     const date = Object.prototype.toString.call(value) === '[object Date]' ? value : undefined;
-    const formattedDate = date === undefined ? inputFormat(value) : '';
+    const formattedDate = date === undefined ? '' : inputFormat(value);
 
     return (
       <div data-react-toolbox='date-picker'>


### PR DESCRIPTION
This fixes issues with PR #474 where the formatted date ternary's true/false was wrong way round.

Sorry about that @javivelasco, I must have switched !== to === after I finished testing, and not swapped the true/false values.
