### PR TITLE
fixed overflow for unrender overlay

### DIFF
--- a/components/button/_config.scss
+++ b/components/button/_config.scss
@@ -4,7 +4,7 @@ $button-neutral-color-hover: rgba($palette-grey-900, .2) !default;
 $button-primary-color-contrast: $color-primary-contrast !default;
 $button-primary-color-hover: rgba($color-primary, .2) !default;
 $button-primary-color: $color-primary !default;
-$button-accent-color-contrast: $color-primary-contrast !default;
+$button-accent-color-contrast: $color-accent-contrast !default;
 $button-accent-color-hover: rgba($color-accent, .2) !default;
 $button-accent-color: $color-accent !default;
 $button-disabled-text-color: rgba($color-black, 0.26) !default;

--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -68,7 +68,7 @@ class Portal extends Component {
 
   _unrenderOverlay () {
     if (this._overlayTarget) {
-      if (this.props.lockBody) document.body.style.overflow = 'scroll';
+      if (this.props.lockBody) document.body.style.overflow = 'auto';
       ReactDOM.unmountComponentAtNode(this._overlayTarget);
       this._overlayInstance = null;
     }


### PR DESCRIPTION
I fixed adding style to element body from `overflow: scroll` to `overflow: auto` when overlay is hidding. Now it doesn't add inactive scrollbars to pages with content fitted in window.

Second commit fixed colors in button accent-contrast style.