### PR TITLE
Exclude JSX navigation div if there are no actions

### DIFF
--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -29,7 +29,7 @@ const Dialog = (props) => {
           {props.title ? <h6 className={style.title}>{props.title}</h6> : null}
           {props.children}
         </section>
-        {actions
+        {actions.length
           ? <nav role='navigation' className={style.navigation}>
               {actions}
             </nav>


### PR DESCRIPTION
Due to the navigation padding, the layout of the parent dialog is altered. When there are no actions, the layout fits if we leave out the `<nav>` element when rendering..