### PR TITLE
Add tabs on the bottom option for the tab component.

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -8,6 +8,7 @@ class Tabs extends React.Component {
     children: React.PropTypes.node,
     className: React.PropTypes.string,
     disableAnimatedBottomBorder: React.PropTypes.bool,
+    tabsOnBottom: React.PropTypes.bool,
     index: React.PropTypes.number,
     onChange: React.PropTypes.func
   };
@@ -61,7 +62,6 @@ class Tabs extends React.Component {
       const label = this.refs.navigation.children[idx].getBoundingClientRect();
       this.setState({
         pointer: {
-          top: `${this.refs.navigation.getBoundingClientRect().height}px`,
           left: `${label.left - startPoint}px`,
           width: `${label.width}px`
         }
@@ -93,6 +93,48 @@ class Tabs extends React.Component {
     }
   }
 
+  renderNavHeaders (headers) {
+    return (
+      <nav className={this.props.tabsOnBottom ? style.topNavigation : style.bottomNavigation} ref='navigation'>
+        {this.renderHeaders(headers)}
+      </nav>
+    );
+  }
+
+  renderNavPointer () {
+    return (
+      <span className={style.pointer} style={this.state.pointer} />
+    );
+  }
+
+  renderNav (headers) {
+    let nav = this.renderNavHeaders(headers);
+    let pointer = this.renderNavPointer();
+
+    return (
+      <div>
+        {this.props.tabsOnBottom ? pointer : nav}
+        {this.props.tabsOnBottom ? nav : pointer}
+      </div>
+    )
+  }
+
+  renderSection (headers, contents, renderTopContents) {
+    if (renderTopContents) {
+      return this.renderContents(contents);
+    } else {
+      return this.renderNav(headers);
+    }
+  }
+
+  renderTopContent (headers, contents) {
+    return this.renderSection(headers, contents, this.props.tabsOnBottom)
+  }
+
+  renderBottomContent (headers, contents) {
+    return this.renderSection(headers, contents, !this.props.tabsOnBottom)
+  }
+
   render () {
     let className = style.root;
     const { headers, contents } = this.parseChildren();
@@ -100,11 +142,8 @@ class Tabs extends React.Component {
 
     return (
       <div ref='tabs' data-react-toolbox='tabs' className={className}>
-        <nav className={style.navigation} ref='navigation'>
-          {this.renderHeaders(headers)}
-        </nav>
-        <span className={style.pointer} style={this.state.pointer} />
-        {this.renderContents(contents)}
+        {this.renderTopContent(headers, contents)}
+        {this.renderBottomContent(headers, contents)}
       </div>
     );
   }

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -116,7 +116,7 @@ class Tabs extends React.Component {
         {this.props.tabsOnBottom ? pointer : nav}
         {this.props.tabsOnBottom ? nav : pointer}
       </div>
-    )
+    );
   }
 
   renderSection (headers, contents, renderTopContents) {
@@ -128,11 +128,11 @@ class Tabs extends React.Component {
   }
 
   renderTopContent (headers, contents) {
-    return this.renderSection(headers, contents, this.props.tabsOnBottom)
+    return this.renderSection(headers, contents, this.props.tabsOnBottom);
   }
 
   renderBottomContent (headers, contents) {
-    return this.renderSection(headers, contents, !this.props.tabsOnBottom)
+    return this.renderSection(headers, contents, !this.props.tabsOnBottom);
   }
 
   render () {

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -8,9 +8,9 @@ class Tabs extends React.Component {
     children: React.PropTypes.node,
     className: React.PropTypes.string,
     disableAnimatedBottomBorder: React.PropTypes.bool,
-    tabsOnBottom: React.PropTypes.bool,
     index: React.PropTypes.number,
-    onChange: React.PropTypes.func
+    onChange: React.PropTypes.func,
+    tabsOnBottom: React.PropTypes.bool
   };
 
   static defaultProps = {
@@ -108,8 +108,8 @@ class Tabs extends React.Component {
   }
 
   renderNav (headers) {
-    let nav = this.renderNavHeaders(headers);
-    let pointer = this.renderNavPointer();
+    const nav = this.renderNavHeaders(headers);
+    const pointer = this.renderNavPointer();
 
     return (
       <div>

--- a/components/tabs/readme.md
+++ b/components/tabs/readme.md
@@ -41,6 +41,7 @@ This component acts as the wrapper and the main controller of the content that i
 |:-----|:-----|:-----|:-----|
 | `className`                   | `String`        | `''`            | Additional class name to provide custom styling.|
 | `disableAnimatedBottomBorder` | `Boolean`       | `false`         | Disable the animation below the active tab.|
+| `tabsOnBottom`                | `Boolean`       | `false`         | Position the tabs under the tab content.|
 | `index`                       | `Number`        | `0`             | Current <Tab> |
 | `onChange`                    | `Function`      |                 | Callback function that is fired when the tab changes.|
 

--- a/components/tabs/style.scss
+++ b/components/tabs/style.scss
@@ -7,7 +7,13 @@
   flex-direction: column;
 }
 
-.navigation {
+.topNavigation {
+  display: flex;
+  flex-direction: row;
+  box-shadow: inset 0 1px $tab-navigation-border-color;
+}
+
+.bottomNavigation {
   display: flex;
   flex-direction: row;
   box-shadow: inset 0 -1px $tab-navigation-border-color;


### PR DESCRIPTION
I wanted tabs on the bottom so I've made an addition to support that. 

I'm new to React and have been away from front-end web dev for a while so if anything isn't standard or best practice let me know what needs to be changed. Thanks!

This is an image of `http://react-toolbox.com/#/components/tabs` with `tabsOnBottom` set to `true`.

```javascript
<Tabs tabsOnBottom={true} index={this.state.index} onChange={this.handleTabChange}>
```

![screen shot 2016-05-04 at 2 06 09 am](https://cloud.githubusercontent.com/assets/1313555/15034955/9ffb8474-1230-11e6-9458-811085a7da52.png)