### PR TITLE
Media queries for dialogs to set wider widths for smaller screens

### DIFF
--- a/components/dialog/style.scss
+++ b/components/dialog/style.scss
@@ -23,10 +23,22 @@
 
 .small {
   width: 30vw;
+  
+  @media screen and (max-width: $layout-breakpoint-sm-tablet) {
+	width: 50vw;
+  }
+  
+  @media screen and (max-width: $layout-breakpoint-xs) {
+	width: 75vw;
+  }
 }
 
 .normal {
   width: 50vw;
+  
+  @media screen and (max-width: $layout-breakpoint-xs) {
+	width: 96vw;
+  }
 }
 
 .large {


### PR DESCRIPTION
Dialogs are squashed on smaller devices. Therefore, I've added media queries to address this: `large` is unchanged; `normal` becomes `96vw` on `$layout-breakpoint-xs`; And, `small` becomes `75vw` on `$layout-breakpoint-xs` and `50vw` on `$layout-breakpoint-sm-tablet`