### PR TITLE
Set corejs as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "toolkit"
   ],
   "dependencies": {
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "core-js": "^2.4.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",
@@ -50,7 +51,6 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "bluebird": "^3.3.5",
-    "core-js": "^2.4.0",
     "cpx": "^1.3.1",
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
Closes issue #382 

It's currently a dev dependency and it works because npm@v3 flattens the dependencies but it's actually a dependency and should be treated as such.