### PR TITLE
Fix display issue with slider

### DIFF
--- a/components/slider/Slider.js
+++ b/components/slider/Slider.js
@@ -191,8 +191,14 @@ class Slider extends React.Component {
   }
 
   trimValue (value) {
-    if (value < this.props.min) return this.props.min;
-    if (value > this.props.max) return this.props.max;
+    if (this.props.min < this.props.max) {
+      if (value < this.props.min) return this.props.min;
+      if (value > this.props.max) return this.props.max;
+    }
+    else if (this.props.min > this.props.max) {
+      if (value > this.props.min) return this.props.min;
+      if (value < this.props.max) return this.props.max;
+    }
     return utils.round(value, this.stepDecimals());
   }
 

--- a/components/slider/style.scss
+++ b/components/slider/style.scss
@@ -89,6 +89,7 @@
   .innerprogress {
     position: absolute;
     top: $slider-knob-size / 2 - $slider-bar-height / 2;
+    left: 0;
     height: $slider-bar-height;
     [data-ref="value"] {
       transition-duration: 0s;


### PR DESCRIPTION
The innerprogress seemed moved on certain browser versions.
Added `left: 0` property to .innerprogress