### PR TITLE
Modify Button's display to be inline-flex

### DIFF
--- a/components/button/style.scss
+++ b/components/button/style.scss
@@ -4,7 +4,7 @@
 %button {
   @include typo-button();
   position: relative;
-  display: inline-block;
+  display: inline-flex;
   height: $button-height;
   flex-direction: row;
   align-content: center;


### PR DESCRIPTION
Text of ``label`` in ``<Button />`` is not aligned with the icon. This is because the ``<Button />`` has ``inline-block`` and not ``inline-flex``, so the ``align-items`` rule has no effect.
Changed the ``inline-block`` declaration into ``inline-flex``.