### PR TITLE
Ie slider fix

### DIFF
--- a/components/utils/events.js
+++ b/components/utils/events.js
@@ -2,14 +2,14 @@ export default {
   getMousePosition (event) {
     return {
       x: event.pageX - (window.scrollX || window.pageXOffset),
-      y: event.pageY - (window.scrollY || window.pageXOffset)
+      y: event.pageY - (window.scrollY || window.pageYOffset)
     };
   },
 
   getTouchPosition (event) {
     return {
       x: event.touches[0].pageX - (window.scrollX || window.pageXOffset),
-      y: event.touches[0].pageY - (window.scrollY || window.pageXOffset)
+      y: event.touches[0].pageY - (window.scrollY || window.pageYOffset)
     };
   },
 

--- a/components/utils/events.js
+++ b/components/utils/events.js
@@ -1,15 +1,15 @@
 export default {
   getMousePosition (event) {
     return {
-      x: event.pageX - window.scrollX,
-      y: event.pageY - window.scrollY
+      x: event.pageX - (window.scrollX || window.pageXOffset),
+      y: event.pageY - (window.scrollY || window.pageXOffset)
     };
   },
 
   getTouchPosition (event) {
     return {
-      x: event.touches[0].pageX - window.scrollX,
-      y: event.touches[0].pageY - window.scrollY
+      x: event.touches[0].pageX - (window.scrollX || window.pageXOffset),
+      y: event.touches[0].pageY - (window.scrollY || window.pageXOffset)
     };
   },
 


### PR DESCRIPTION
Interacting with the Slider was sending NaN to the change handler for me in IE 10 and 11 which doesn't seem to have window.scrollX / Y. Change uses an alternative IE property and fixed it for me.