### PR TITLE
small fix for autocomplete component

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -45,7 +45,9 @@ class Autocomplete extends React.Component {
 
  componentWillReceiveProps (nextProps) {
    if (!this.props.multiple) {
-     this.setState({query: nextProps.value});
+     this.setState({
+       query: this.query(nextProps.value)
+     });
    }
  }
 


### PR DESCRIPTION
For `multiple=false` components value is broken, because it isn't extracted from Map.

If I'm trying to use key/value object as source I get key instead value (in input) as expected. But after full render of component value is visible again.