### PR TITLE
feat(datepicker,timepicker): add support for `name` prop

### DIFF
--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -23,6 +23,7 @@ const factory = (Input, DatePickerDialog) => {
       ]),
       inputClassName: PropTypes.string,
       inputFormat: PropTypes.func,
+      name: PropTypes.string,
       label: PropTypes.string,
       maxDate: PropTypes.object,
       minDate: PropTypes.object,
@@ -66,6 +67,7 @@ const factory = (Input, DatePickerDialog) => {
             className={classnames(this.props.theme.input, {[inputClassName]: inputClassName })}
             error={this.props.error}
             onMouseDown={this.handleInputMouseDown}
+            name={this.props.name}
             label={this.props.label}
             readOnly
             type='text'
@@ -76,6 +78,7 @@ const factory = (Input, DatePickerDialog) => {
             autoOk={this.props.autoOk}
             active={this.state.active}
             className={this.props.className}
+            name={this.props.name}
             maxDate={this.props.maxDate}
             minDate={this.props.minDate}
             onDismiss={this.handleDismiss}

--- a/components/date_picker/DatePickerDialog.js
+++ b/components/date_picker/DatePickerDialog.js
@@ -10,6 +10,7 @@ const factory = (Dialog, Calendar) => {
       className: PropTypes.string,
       maxDate: PropTypes.object,
       minDate: PropTypes.object,
+      name: PropTypes.string,
       onDismiss: PropTypes.func,
       onSelect: PropTypes.func,
       theme: PropTypes.shape({
@@ -74,7 +75,7 @@ const factory = (Dialog, Calendar) => {
 
     actions = [
       { label: 'Cancel', className: this.props.theme.button, onClick: this.props.onDismiss },
-      { label: 'Ok', className: this.props.theme.button, onClick: this.handleSelect }
+      { label: 'Ok', className: this.props.theme.button, name: this.props.name, onClick: this.handleSelect }
     ];
 
     render () {

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -17,6 +17,7 @@ const factory = (FontIcon) => {
         React.PropTypes.string,
         React.PropTypes.element
       ]),
+      name: React.PropTypes.string,
       label: React.PropTypes.string,
       maxLength: React.PropTypes.number,
       multiline: React.PropTypes.bool,
@@ -67,7 +68,7 @@ const factory = (FontIcon) => {
 
     render () {
       const { children, disabled, error, floating, hint, icon,
-              label: labelText, maxLength, multiline, required,
+              name, label: labelText, maxLength, multiline, required,
               theme, type, value, ...others} = this.props;
       const length = maxLength && value ? value.length : 0;
       const labelClassName = classnames(theme.label, {[theme.fixed]: !floating});
@@ -87,6 +88,7 @@ const factory = (FontIcon) => {
         onChange: this.handleChange,
         ref: 'input',
         role: 'input',
+        name,
         disabled,
         required,
         type,

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -15,6 +15,7 @@ const factory = (TimePickerDialog, Input) => {
       error: PropTypes.string,
       format: PropTypes.oneOf(['24hr', 'ampm']),
       inputClassName: PropTypes.string,
+      name: PropTypes.string,
       label: PropTypes.string,
       onChange: PropTypes.func,
       theme: PropTypes.shape({
@@ -54,6 +55,7 @@ const factory = (TimePickerDialog, Input) => {
           <Input
             className={classnames(theme.input, {[inputClassName]: inputClassName })}
             error={this.props.error}
+            name={this.props.name}
             label={this.props.label}
             onMouseDown={this.handleInputMouseDown}
             readOnly
@@ -63,6 +65,7 @@ const factory = (TimePickerDialog, Input) => {
           <TimePickerDialog
             active={this.state.active}
             className={this.props.className}
+            name={this.props.name}
             format={format}
             onDismiss={this.handleDismiss}
             onSelect={this.handleSelect}

--- a/components/time_picker/TimePickerDialog.js
+++ b/components/time_picker/TimePickerDialog.js
@@ -9,6 +9,7 @@ const factory = (Dialog) => {
       active: PropTypes.bool,
       className: PropTypes.string,
       format: PropTypes.oneOf(['24hr', 'ampm']),
+      name: PropTypes.string,
       onDismiss: PropTypes.func,
       onSelect: PropTypes.func,
       theme: PropTypes.shape({
@@ -68,7 +69,7 @@ const factory = (Dialog) => {
 
     actions = [
       { label: 'Cancel', className: this.props.theme.button, onClick: this.props.onDismiss },
-      { label: 'Ok', className: this.props.theme.button, onClick: this.handleSelect }
+      { label: 'Ok', className: this.props.theme.button, name: this.props.name, onClick: this.handleSelect }
     ];
 
     formatHours () {


### PR DESCRIPTION
Just added `name`-prop support for both Input, Timepicker and Datepicker components.

This enables to use `ev.target.name` to easily get the control name of the control form element. Thus being able to use the same `onChange` handler for several inputs/components.

This makes Datepicker/Timepicker act a little bit more like regular inputs (which is what they are ultimately, before being heavily decorated).

More info on MDN:

`name: The name of the control, which is submitted with the form data.`

- https://developer.mozilla.org/en/docs/Web/HTML/Element/Input
- https://developer.mozilla.org/en/docs/Web/HTML/Element/Button