### PR TITLE
Snackbar has `transition: all` and it seems un-needed...

### DIFF
--- a/components/snackbar/theme.scss
+++ b/components/snackbar/theme.scss
@@ -17,7 +17,7 @@
   color: $snackbar-color;
   background-color: $snackbar-background-color;
   border-radius: $snackbar-border-radius;
-  transition: all $animation-duration $animation-curve-default $animation-duration;
+  transition: transform $animation-duration $animation-curve-default $animation-duration;
   &.accept .button {
     color: $snackbar-color-accept;
   }


### PR DESCRIPTION
The `transition: all` on the `<Snackbar>` element was causing weird things like my color to transition from one color to another when it changed.

I felt that this was a bit un-intuitive. I expected the element to only apply the transition timings to the transforms it does to "pop up" and "close down".

This is a very small change to have it act that way.

Feel free to close this PR if you feel it's working as intended as is, and if you need me to i can run the build command and re-commit the change with the `lib` dir built as well.