### PR TITLE
Fix pointer-events for Overlay in 1.0

### DIFF
--- a/components/overlay/theme.scss
+++ b/components/overlay/theme.scss
@@ -16,7 +16,7 @@
   align-items: center;
   justify-content: center;
   pointer-events: none;
-  &.invisible > *:not(.overlay) {
+  &.invisible > *:not(.backdrop) {
     pointer-events: all;
   }
 }

--- a/components/snackbar/theme.scss
+++ b/components/snackbar/theme.scss
@@ -17,7 +17,7 @@
   color: $snackbar-color;
   background-color: $snackbar-background-color;
   border-radius: $snackbar-border-radius;
-  transition: all $animation-duration $animation-curve-default $animation-duration;
+  transition: transform $animation-duration $animation-curve-default $animation-duration;
   &.accept .button {
     color: $snackbar-color-accept;
   }

--- a/components/snackbar/theme.scss
+++ b/components/snackbar/theme.scss
@@ -17,7 +17,7 @@
   color: $snackbar-color;
   background-color: $snackbar-background-color;
   border-radius: $snackbar-border-radius;
-  transition: transform $animation-duration $animation-curve-default $animation-duration;
+  transition: all $animation-duration $animation-curve-default $animation-duration;
   &.accept .button {
     color: $snackbar-color-accept;
   }


### PR DESCRIPTION
Looking at git-blame it looks like in commit [#f6d2d3f9](https://github.com/react-toolbox/react-toolbox/commit/f6d2d3f95d2c2771b4ebd7fe2e7f992a46dd6a39) broke the handling of the `transparent` prop and `pointer-events` in the `<Overlay>` element. (basically re-opening #178)


The sass had `&.invisible > *:not(.overlay) {` which looks like it should have been `&.invisible > *:not(.backdrop) {` with the updated sass for the theme stuff.

This fixes the issue for me. Again let me know if you want me to run the build on my own, i can do that before this is merged. (and sorry about the 3 commits, one from the other PR got in there and I had to revert it)