### PR TITLE
Patch feat name prop

### DIFF
--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -12,6 +12,7 @@ const factory = (Check) => {
       className: PropTypes.string,
       disabled: PropTypes.bool,
       label: PropTypes.any,
+      name: PropTypes.string,
       onChange: PropTypes.func,
       theme: PropTypes.shape({
         disabled: PropTypes.string,

--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -23,10 +23,10 @@ const factory = (Input, DatePickerDialog) => {
       ]),
       inputClassName: PropTypes.string,
       inputFormat: PropTypes.func,
-      name: PropTypes.string,
       label: PropTypes.string,
       maxDate: PropTypes.object,
       minDate: PropTypes.object,
+      name: PropTypes.string,
       onChange: PropTypes.func,
       theme: PropTypes.shape({
         input: PropTypes.string

--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -15,6 +15,7 @@ const factory = (Input) => {
       disabled: PropTypes.bool,
       error: PropTypes.string,
       label: PropTypes.string,
+      name: PropTypes.string,
       onBlur: PropTypes.func,
       onChange: PropTypes.func,
       onFocus: PropTypes.func,
@@ -94,6 +95,9 @@ const factory = (Input) => {
     handleSelect = (item, event) => {
       if (this.props.onBlur) this.props.onBlur(event);
       if (!this.props.disabled && this.props.onChange) {
+        if (this.props.name) {
+          event.target.name = this.props.name;
+        }
         this.props.onChange(item, event);
         this.setState({active: false});
       }

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -17,10 +17,10 @@ const factory = (FontIcon) => {
         React.PropTypes.string,
         React.PropTypes.element
       ]),
-      name: React.PropTypes.string,
       label: React.PropTypes.string,
       maxLength: React.PropTypes.number,
       multiline: React.PropTypes.bool,
+      name: React.PropTypes.string,
       onBlur: React.PropTypes.func,
       onChange: React.PropTypes.func,
       onFocus: React.PropTypes.func,

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -15,8 +15,8 @@ const factory = (TimePickerDialog, Input) => {
       error: PropTypes.string,
       format: PropTypes.oneOf(['24hr', 'ampm']),
       inputClassName: PropTypes.string,
-      name: PropTypes.string,
       label: PropTypes.string,
+      name: PropTypes.string,
       onChange: PropTypes.func,
       theme: PropTypes.shape({
         input: PropTypes.string


### PR DESCRIPTION
Added name prop support for the `Dropdown` component. Since the emitted target is currently a `<li>` and not an input, I could not leverage the input `name` attribute.

Some minor propTypes re-ordering following #546 to fix eslint warnings.
