### PR TITLE
[Fixes #550] Add PropType checking to Menu's position and update docs

### DIFF
--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -25,7 +25,7 @@ const factory = (MenuItem) => {
       onSelect: PropTypes.func,
       onShow: PropTypes.func,
       outline: PropTypes.bool,
-      position: PropTypes.string,
+      position: PropTypes.oneOf(Object.keys(POSITION).map(key => POSITION[key])),
       ripple: PropTypes.bool,
       selectable: PropTypes.bool,
       selected: PropTypes.any,

--- a/components/menu/readme.md
+++ b/components/menu/readme.md
@@ -7,7 +7,7 @@ A [Menu](https://www.google.com/design/spec/components/menus.html) is a temporar
 import {IconMenu, MenuItem, MenuDivider } from 'react-toolbox/lib/menu';
 
 const MenuTest = () => (
-  <IconMenu icon='more_vert' position='top-left' menuRipple>
+  <IconMenu icon='more_vert' position='topLeft' menuRipple>
     <MenuItem value='download' icon='get_app' caption='Download' />
     <MenuItem value='help' icon='favorite' caption='Favorite' />
     <MenuItem value='settings' icon='open_in_browser' caption='Open in app' />
@@ -33,7 +33,7 @@ This subcomponent is the default wrapper for a menu and is responsible for the o
 | `onSelect`    | `Function`    |             | Callback that will be invoked when a menu item is selected. |
 | `onShow`      | `Function`    |             | Callback that will be invoked when the menu is being shown. |
 | `outline`     | `Boolean`     | `true`      | If true the menu wrapper will show an outline with a soft shadow. |
-| `position`    | `String`      | `static`    | Determine the position of the menu. With `static` value the menu will be always shown, `auto` means that the it will decide the opening direction based on the current position. To force a position use `top-left`, `top-right`, `bottom-left`, `bottom-right`. |
+| `position`    | `String`      | `static`    | Determine the position of the menu. With `static` value the menu will be always shown, `auto` means that the it will decide the opening direction based on the current position. To force a position use `topLeft`, `topRight`, `bottomLeft`, `bottomRight`. |
 | `ripple`      | `Boolean`     | `true`      | If true, the menu items will show a ripple effect on click. |
 | `selectable`  | `Boolean`     | `false`     | If true, the menu will keep a value to highlight the active child item. |
 | `selected`    | `Any`         |             | Used for selectable menus. Indicates the current selected value so the child item with this value can be highlighted. |

--- a/docs/app/components/layout/main/modules/examples/menu_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/menu_example_1.txt
@@ -1,5 +1,5 @@
 const MenuTest = () => (
-  <IconMenu icon='more_vert' position='top-left' menuRipple>
+  <IconMenu icon='more_vert' position='topLeft' menuRipple>
     <MenuItem value='download' icon='get_app' caption='Download' />
     <MenuItem value='help' icon='favorite' caption='Favorite' />
     <MenuItem value='settings' icon='open_in_browser' caption='Open in app' />


### PR DESCRIPTION
I got burned by Issue #550 when upgrading to 1.0.0. The position property on Menu got moved from dashes to camelCase, but the docs weren't updated.

This PR updates the docs, and adds a PropType check on position.