### PR TITLE
Fix MenuItem onclick called without event

### DIFF
--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -121,10 +121,11 @@ const factory = (MenuItem) => {
       }
     };
 
-    handleSelect = (item) => {
+    handleSelect = (item, event) => {
       const { value, onClick } = item.props;
+      if (onClick) event.persist();
       this.setState({ active: false, rippled: this.props.ripple }, () => {
-        if (onClick) onClick();
+        if (onClick) onClick(event);
         if (this.props.onSelect) this.props.onSelect(value);
       });
     };

--- a/components/menu/__test__/index.spec.js
+++ b/components/menu/__test__/index.spec.js
@@ -1,0 +1,29 @@
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-addons-test-utils';
+import Menu from '../Menu';
+import MenuItem, {MenuItem as RawMenuItem} from '../MenuItem';
+
+describe('MenuItem', function () {
+  describe('#onClick', function () {
+    it('passes to listener the event', function () {
+      let listenerCalled = false;
+      const handleClick = function (event) {
+        listenerCalled = true;
+        expect(event).toExist();
+        expect(event.target).toExist();
+      };
+
+      const tree = ReactTestUtils.renderIntoDocument(
+        <Menu>
+          <MenuItem key="1" onClick={handleClick}/>
+        </Menu>);
+
+      const menuItem = ReactTestUtils.findRenderedComponentWithType(tree, RawMenuItem);
+      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(menuItem));
+
+      expect(listenerCalled).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
In all other cases the event listener receives the event. I need to receive the event to stop its propagation.