### PR TITLE
Fix hanging timeout on <Snackbar/> element

### DIFF
--- a/components/snackbar/Snackbar.js
+++ b/components/snackbar/Snackbar.js
@@ -44,6 +44,10 @@ const factory = (Overlay, Button) => {
       }
     }
 
+    componentWillUnmount () {
+      clearTimeout(this.curTimeout);
+    }
+
     render () {
       const {action, active, icon, label, onClick, theme, type } = this.props;
       const className = classnames([theme.snackbar, theme[type]], {


### PR DESCRIPTION
The `<Snackbar/>` element sets a timeout if you set the timeout and onTimeout props on the element. If the element is unmounted before those props fire, they can possibly fire on an un-mounted parent element.

This fix just puts an componentWillUnmount handler on the Snackbar element and has it clear it's timeout when it unmounts which prevents that issue.