### PR TITLE
Fixed bug with changes months on datepicker

### DIFF
--- a/components/utils/time.js
+++ b/components/utils/time.js
@@ -104,7 +104,7 @@ const time = {
 
   addMonths (d, months) {
     const newDate = this.clone(d);
-    newDate.setMonth(d.getMonth() + months);
+    newDate.setMonth(d.getMonth() + months, 1);
     return newDate;
   },
 

--- a/lib/utils/time.js
+++ b/lib/utils/time.js
@@ -139,7 +139,7 @@ var time = {
   },
   addMonths: function addMonths(d, months) {
     var newDate = this.clone(d);
-    newDate.setMonth(d.getMonth() + months);
+    newDate.setMonth(d.getMonth() + months, 1);
     return newDate;
   },
   addYears: function addYears(d, years) {


### PR DESCRIPTION
This is an issue with using the `.setMonth` method when the current day value is larger than the largest day value of the month being set.

When setting a new month, we now set the date to the first day of the month.

E.g.
Adding 1 month to `Jan 31`, means it tries to set the date to `Feb 31` which doesn't exist and therefore it instead sets the date to `Mar 02`.

```
var theDate = new Date('01 31 2016')
theDate.setMonth(1)
console.log(theDate) // 03 02 2016

var theNewDate = new Date('01 31 2016')
theNewDate.setMonth(1, 1)
console.log(theNewDate) // 02 01 2016
```

Fixes issue #533