### PR TITLE
Fix cpx command to work correctly when coping sass and ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
     "prebuild": "npm run clean",
     "prepublish": "npm run build",
     "release": "bumped release",
-    "sass": "cpx ./components/**/*.scss ./lib",
-    "tsd": "cpx ./components/**/*.d.ts ./lib",
+    "sass": "cpx './components/**/*.scss' ./lib",
+    "tsd": "cpx './components/**/*.d.ts' ./lib",
     "start": "cross-env NODE_ENV=development UV_THREADPOOL_SIZE=100 node ./server",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test karma start --no-single-run"


### PR DESCRIPTION
The current `npm run sass` and `npm run tsd` failed on my machine (OSX) because the `cpx` target was not put in quotation marks.