### PR TITLE
Add 'suggestionMatch' prop to Autocomplete component

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -26,6 +26,7 @@ const factory = (Chip, Input) => {
      selectedPosition: PropTypes.oneOf(['above', 'below']),
      showSuggestionsWhenValueIsSet: PropTypes.bool,
      source: PropTypes.any,
+     suggestionMatch: PropTypes.oneOf(['start', 'anywhere', 'word']),
      theme: PropTypes.shape({
        active: PropTypes.string,
        autocomplete: PropTypes.string,
@@ -47,7 +48,8 @@ const factory = (Chip, Input) => {
      selectedPosition: 'above',
      multiple: true,
      showSuggestionsWhenValueIsSet: false,
-     source: {}
+     source: {},
+     suggestionMatch: 'start'
    };
 
    state = {
@@ -151,7 +153,7 @@ const factory = (Chip, Input) => {
      // Suggest any non-set value which matches the query
      if (this.props.multiple) {
        for (const [key, value] of source) {
-         if (!values.has(key) && value.toLowerCase().trim().startsWith(query)) {
+         if (!values.has(key) && this.matches(value.toLowerCase().trim(), query)) {
            suggest.set(key, value);
          }
        }
@@ -159,7 +161,7 @@ const factory = (Chip, Input) => {
      // When multiple is false, suggest any value which matches the query if showAllSuggestions is false
      } else if (query && !this.state.showAllSuggestions) {
        for (const [key, value] of source) {
-         if (value.toLowerCase().trim().startsWith(query)) {
+         if (this.matches(value.toLowerCase().trim(), query)) {
            suggest.set(key, value);
          }
        }
@@ -170,6 +172,21 @@ const factory = (Chip, Input) => {
      }
 
      return suggest;
+   }
+
+   matches (value, query) {
+     const { suggestionMatch } = this.props;
+
+     if (suggestionMatch === 'start') {
+       return value.startsWith(query);
+     } else if (suggestionMatch === 'anywhere') {
+       return value.includes(query);
+     } else if (suggestionMatch === 'word') {
+       const re = new RegExp(`\\b${query}`, 'g');
+       return re.test(value);
+     }
+
+     return false;
    }
 
    source () {

--- a/components/autocomplete/readme.md
+++ b/components/autocomplete/readme.md
@@ -53,6 +53,7 @@ If you want to provide a theme via context, the component key is `RTAutocomplete
 | `source`            | `Object` or `Array`    |                 | Object of key/values or array representing all items suggested. |
 | `selectedPosition`  | `String`               |  `above`        | Determines if the selected list is shown above or below input. It can be `above` or `below`. |
 | `showSuggestionsWhenValueIsSet` | `Bool`     | `false`         | If true, the list of suggestions will not be filtered when a value is selected, until the query is modified. |
+| `suggestionMatch`   | `String`               | `start`         | Determines how suggestions are supplied. It can be `start` (query matches the start of a suggestion), `anywhere` (query matches anywhere inside the suggestion), or `word` (query matches the start of a word in the suggestion). |
 | `value`             | `String` or `Array`    |                 | Value or array of values currently selected component.|
 
 Additional properties will be passed to the Input Component so you can use `hint`, `name` ... etc.

--- a/spec/components/autocomplete.js
+++ b/spec/components/autocomplete.js
@@ -2,7 +2,8 @@ import React from 'react';
 import Autocomplete from '../../components/autocomplete';
 
 const countriesArray = ['Spain', 'England', 'USA', 'Thailand', 'Tongo', 'Slovenia'];
-const countriesObject = {'ES-es': 'Spain', 'TH-th': 'Thailand', 'EN-gb': 'England', 'EN-en': 'USA'};
+const countriesObject = {'ES-es': 'Spain', 'TH-th': 'Thailand', 'EN-gb': 'England',
+  'EN-en': 'United States of America', 'EN-nz': 'New Zealand'};
 
 class AutocompleteTest extends React.Component {
   state = {
@@ -34,6 +35,7 @@ class AutocompleteTest extends React.Component {
           label="Pick multiple elements..."
           source={countriesObject}
           value={this.state.multiple}
+          suggestionMatch="anywhere"
         />
 
         <Autocomplete


### PR DESCRIPTION
Fixes #566 

Add `suggestionMatch` prop to Autocomplete component to determine how suggestions are matched.

It can be:

- `start`: query matches the start of a suggestion - eg. `ne` will match `new zealand`

- `anywhere`: query matches anywhere inside the suggestion - eg. `land` will match `new zealand` and `thailand` and `england`

- `word`: query matches the start of a word in the suggestion - eg. `zea` will match `new zealand`


Defaults to `start` to maintain consistency with current behavior.