### PR TITLE
Added ability to export the DatePickerDialog separately from the DatePicker

### DIFF
--- a/components/date_picker/index.js
+++ b/components/date_picker/index.js
@@ -1,7 +1,7 @@
 export default from './DatePicker';
 
 import { themr } from 'react-css-themr';
-import { DATE_PICKER } from '../identifiers.js';
+import { DATE_PICKER, DIALOG } from '../identifiers.js';
 import { datePickerFactory } from './DatePicker.js';
 import datePickerDialogFactory from './DatePickerDialog.js';
 import calendarFactory from './Calendar.js';
@@ -18,3 +18,6 @@ const DatePicker = datePickerFactory(Input, DatePickerDialog);
 const ThemedDatePicker = themr(DATE_PICKER, theme)(DatePicker);
 export default ThemedDatePicker;
 export { ThemedDatePicker as DatePicker };
+
+const ThemedDatePickerDialog = themr(DIALOG, theme)(DatePickerDialog);
+export { ThemedDatePickerDialog as DatePickerDialog };

--- a/lib/date_picker/index.js
+++ b/lib/date_picker/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.DatePicker = exports.default = undefined;
+exports.DatePickerDialog = exports.DatePicker = exports.default = undefined;
 
 var _DatePicker = require('./DatePicker');
 
@@ -49,3 +49,7 @@ var DatePicker = (0, _DatePicker3.datePickerFactory)(_input2.default, DatePicker
 var ThemedDatePicker = (0, _reactCssThemr.themr)(_identifiers.DATE_PICKER, _theme2.default)(DatePicker);
 exports.default = ThemedDatePicker;
 exports.DatePicker = ThemedDatePicker;
+
+
+var ThemedDatePickerDialog = (0, _reactCssThemr.themr)(_identifiers.DIALOG, _theme2.default)(DatePickerDialog);
+exports.DatePickerDialog = ThemedDatePickerDialog;


### PR DESCRIPTION
Our project required the calendar (`DatePickerDialog`) without the entire `DatePicker` that went with it.

With the change to v1.0.0 this was no longer being exported, so this update simply exports `DatePickerDialog` and `DatePicker`