### PR TITLE
chore(dropdown): set value to empty string to prevent uncontrolled er…

### DIFF
--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -153,7 +153,7 @@ const factory = (Input) => {
             onMouseDown={this.handleMouseDown}
             readOnly
             type={template && selected ? 'hidden' : null}
-            value={selected && selected.label}
+            value={selected && selected.label ? selected.label : ''}
           />
         {template && selected ? this.renderTemplateValue(selected) : null}
           <ul className={theme.values} ref='values'>


### PR DESCRIPTION
With the current implementation, `react@^15` spills warnings about uncontrolled inputs:

```
warning.js?746c:44 Warning: Input is changing a controlled input of type null to be uncontrolled. Input elements should not switch from controlled to uncontrolled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components
```

Setting the value to be an empty string `''` instead of `false` does fix that.