### PR TITLE
Bugfix: Reset overflow when unmounting an overlay

### DIFF
--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -43,6 +43,7 @@ class Overlay extends Component {
   }
 
   componentWillUnmount () {
+    document.body.style.overflow = null;
     if (this.escKeyListener) {
       document.body.removeEventListener('keydown', this.handleEscKey);
       this.escKeyListener = null;

--- a/lib/overlay/Overlay.js
+++ b/lib/overlay/Overlay.js
@@ -66,6 +66,7 @@ var Overlay = function (_Component) {
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
+      document.body.style.overflow = null;
       if (this.escKeyListener) {
         document.body.removeEventListener('keydown', this.handleEscKey);
         this.escKeyListener = null;


### PR DESCRIPTION
Fixes issue where scrolling is disabled after overlay is unmounted.

When used in a menu componentWillUpdate may not be called when clicking on a menu item, resetting overflow on body on componentWillUnmount ensures you can scroll after using the menu.