### PR TITLE
missing MENU for some reason in identifiers

### DIFF
--- a/components/identifiers.js
+++ b/components/identifiers.js
@@ -11,6 +11,7 @@ export const INPUT = 'RTInput';
 export const LAYOUT = 'RTLayout';
 export const LINK = 'RTLink';
 export const LIST = 'RTList';
+export const MENU = 'RTMenu';
 export const NAVIGATION = 'RTNavigation';
 export const OVERLAY = 'RTOverlay';
 export const PROGRESS_BAR = 'RTProgressBar';


### PR DESCRIPTION
Not quite sure why this went missing - perhaps a bad merge?