### PR TITLE
Fix Number.isNaN TypeError on IE

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -112,7 +112,7 @@ const factory = (FontIcon) => {
         [theme.withIcon]: icon
       }, this.props.className);
 
-      const valuePresent = value !== null && value !== undefined && value !== '' && !Number.isNaN(value);
+      const valuePresent = value !== null && value !== undefined && value !== '' && !isNaN(value);
 
       const InputElement = React.createElement(multiline ? 'textarea' : 'input', {
         ...others,

--- a/lib/input/Input.js
+++ b/lib/input/Input.js
@@ -126,7 +126,7 @@ var factory = function factory(FontIcon) {
 
         var className = (0, _classnames5.default)(theme.input, (_classnames2 = {}, _defineProperty(_classnames2, theme.disabled, disabled), _defineProperty(_classnames2, theme.errored, error), _defineProperty(_classnames2, theme.hidden, type === 'hidden'), _defineProperty(_classnames2, theme.withIcon, icon), _classnames2), this.props.className);
 
-        var valuePresent = value !== null && value !== undefined && value !== '' && !Number.isNaN(value);
+        var valuePresent = value !== null && value !== undefined && value !== '' && !isNaN(value);
 
         var InputElement = _react2.default.createElement(multiline ? 'textarea' : 'input', _extends({}, others, {
           className: (0, _classnames5.default)(theme.inputElement, _defineProperty({}, theme.filled, valuePresent)),


### PR DESCRIPTION
On IE11, some of the components in the docs demo page don't work - Autocomplete and Slider are two examples. They fail with the following message:
> TypeError: Object doesn't support property or method 'isNaN'

I've fixed these by replacing Number.isNaN with isNaN, which is much more widely supported. Of course, it behaves differently when passed values that aren't of type number. I'm not quite sure what ```valuePresent``` is used for, but I hope the switch is acceptable. If not, an alternative Number.isNaN can be added quite easily.