### PR TITLE
Fix date picker month offset in 2 files (as per components/date_picker/readme.md)

### DIFF
--- a/docs/app/components/layout/main/modules/examples/datepicker_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/datepicker_example_1.txt
@@ -30,7 +30,7 @@ class DatePickerTest extends React.Component {
         <DatePicker
           label='Formatted Date'
           autoOk
-          inputFormat={(value) => `${value.getDate()}/${value.getMonth()}/${value.getFullYear()}`}
+          inputFormat={(value) => `${value.getDate()}/${value.getMonth() + 1}/${value.getFullYear()}`}
           onChange={this.handleChange.bind(this, 'date3')}
           value={this.state.date3}
         />

--- a/spec/components/pickers.js
+++ b/spec/components/pickers.js
@@ -43,7 +43,7 @@ class PickersTest extends React.Component {
 
         <DatePicker
           label='Formatted Date'
-          inputFormat={(value) => `${value.getDate()}/${value.getMonth()}/${value.getFullYear()}`}
+          inputFormat={(value) => `${value.getDate()}/${value.getMonth() + 1}/${value.getFullYear()}`}
           onChange={this.handleChange.bind(this, 'date3')}
           value={this.state.date3}
         />


### PR DESCRIPTION
`components/date_picker/readme.md` correctly does a `${value.getMonth() + 1}`, but both
`spec/components/pickers.js` and
`docs/app/components/layout/main/modules/examples/datepicker_example_1.txt`
do `${value.getMonth()}`
and therefore get the "wrong" month number (6 for July, etc)