### PR TITLE
Forward theme prop from Tabs to TabContent

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -52,7 +52,7 @@ const factory = (Tab, TabContent) => {
         if (item.type === Tab) {
           headers.push(item);
           if (item.props.children) {
-            contents.push(<TabContent children={item.props.children} />);
+            contents.push(<TabContent children={item.props.children} theme={this.props.theme} />);
           }
         } else if (item.type === TabContent) {
           contents.push(item);


### PR DESCRIPTION
The `Tabs` component takes a `theme`, but was not forwarding it on to its internal `TabContent` component, so it wasn’t possible to theme the `tabs` or `active` classes.