### PR TITLE
Document CardTitle's cardTitle theme

### DIFF
--- a/components/card/readme.md
+++ b/components/card/readme.md
@@ -73,10 +73,11 @@ A versatile title block that can be used in various places on the card, includin
 
 | Name     | Description|
 |:---------|:-----------|
+| `cardTitle` | Class used for the root element.|
 | `large` | Added to the root element when the card has avatar.|
 | `small` | Added to the root element when the card has no avatar.|
-| `subtitle` | Added to the root element for subtitle.|
-| `title` | Used in for the root element.|
+| `subtitle` | Added to the subtitle element.|
+| `title` | Added to the title element.|
 
 ## CardMedia
 


### PR DESCRIPTION
The `cardTitle` theme for the root `CardTitle` component was not documented.

I also made the wording for `title` and `subtitle` more consistent.