### PR TITLE
added default callbacks for onEscKeyDown & onOverlayClick methods

### DIFF
--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -68,7 +68,7 @@ const factory = (Input, DatePickerDialog) => {
 
     render () {
       const { autoOk, inputClassName, inputFormat, maxDate, minDate,
-        onEscKeyDown, onOverlayClick, value, ...others } = this.props;
+        onEscKeyDown = this.handleDismiss, onOverlayClick = this.handleDismiss, value, ...others } = this.props;
       const finalInputFormat = inputFormat || time.formatDate;
       const date = Object.prototype.toString.call(value) === '[object Date]' ? value : undefined;
       const formattedDate = date === undefined ? '' : finalInputFormat(value);

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -59,7 +59,7 @@ const factory = (TimePickerDialog, Input) => {
     };
 
     render () {
-      const { value, format, inputClassName, onEscKeyDown, onOverlayClick, theme, ...others } = this.props;
+      const { value, format, inputClassName, onEscKeyDown = this.handleDismiss, onOverlayClick = this.handleDismiss, theme, ...others } = this.props;
       const formattedTime = value ? time.formatTime(value, format) : '';
       return (
         <div data-react-toolbox='time-picker'>

--- a/lib/date_picker/DatePicker.js
+++ b/lib/date_picker/DatePicker.js
@@ -104,8 +104,8 @@ var factory = function factory(Input, DatePickerDialog) {
         var inputFormat = _props.inputFormat;
         var maxDate = _props.maxDate;
         var minDate = _props.minDate;
-        var onEscKeyDown = _props.onEscKeyDown;
-        var onOverlayClick = _props.onOverlayClick;
+        var onEscKeyDown = _props.onEscKeyDown || this.handleDismiss;
+        var onOverlayClick = _props.onOverlayClick || this.handleDismiss;
         var value = _props.value;
 
         var others = _objectWithoutProperties(_props, ['autoOk', 'inputClassName', 'inputFormat', 'maxDate', 'minDate', 'onEscKeyDown', 'onOverlayClick', 'value']);

--- a/lib/time_picker/TimePicker.js
+++ b/lib/time_picker/TimePicker.js
@@ -94,8 +94,8 @@ var factory = function factory(TimePickerDialog, Input) {
         var value = _props.value;
         var format = _props.format;
         var inputClassName = _props.inputClassName;
-        var onEscKeyDown = _props.onEscKeyDown;
-        var onOverlayClick = _props.onOverlayClick;
+        var onEscKeyDown = _props.onEscKeyDown || this.handleDismiss;
+        var onOverlayClick = _props.onOverlayClick || this.handleDismiss;
         var theme = _props.theme;
 
         var others = _objectWithoutProperties(_props, ['value', 'format', 'inputClassName', 'onEscKeyDown', 'onOverlayClick', 'theme']);


### PR DESCRIPTION
I added default callbacks for onEscKeyDown & onOverlayClick methods because we can't set state from parent component