### PR TITLE
Fix autocomplete activating on react>=15.1 if no direction

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -72,7 +72,6 @@ const factory = (Chip, Input) => {
        const direction = this.calculateDirection();
        if (this.state.direction !== direction) {
          this.setState({ direction });
-         return false;
        }
      }
      return true;

--- a/lib/autocomplete/Autocomplete.js
+++ b/lib/autocomplete/Autocomplete.js
@@ -139,7 +139,6 @@ var factory = function factory(Chip, Input) {
           var direction = this.calculateDirection();
           if (this.state.direction !== direction) {
             this.setState({ direction: direction });
-            return false;
           }
         }
         return true;


### PR DESCRIPTION
`Autocomplete` will not show suggestions while input is first time activated if no `direction` specified. Bug is here https://github.com/react-toolbox/react-toolbox/blob/dev/components/autocomplete/Autocomplete.js#L71

All worked ok on `react<15.1` due the bug was in react core (twice update, https://github.com/facebook/react/pull/6650). On `react>=15.1' `Autocomplete` is not activated correctly.