### PR TITLE
Only add Input auto-resize handler to multiline inputs

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -55,7 +55,9 @@ const factory = (FontIcon) => {
     };
 
     componentDidMount () {
-      window.addEventListener('resize', this.handleAutoresize);
+      if (this.props.multiline) {
+        window.addEventListener('resize', this.handleAutoresize);
+      }
     }
 
     componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
Without this, resizing a window which contains an `input type=file` causes the Browse button to be resized. I don't think there's any reason to monitor resizing for single line inputs?