### PR TITLE
Ensure theme gets passed down to TimePicker child components

### DIFF
--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -59,13 +59,13 @@ const factory = (TimePickerDialog, Input) => {
     };
 
     render () {
-      const { value, format, inputClassName, onEscKeyDown, onOverlayClick, theme, ...others } = this.props;
+      const { value, format, inputClassName, onEscKeyDown, onOverlayClick, ...others } = this.props;
       const formattedTime = value ? time.formatTime(value, format) : '';
       return (
         <div data-react-toolbox='time-picker'>
           <Input
             {...others}
-            className={classnames(theme.input, {[inputClassName]: inputClassName })}
+            className={classnames(this.props.theme.input, {[inputClassName]: inputClassName })}
             error={this.props.error}
             name={this.props.name}
             label={this.props.label}


### PR DESCRIPTION
Fixes #660 by ensuring that the `theme` prop gets passed down to child components.

Follows the same pattern that `DatePicker` does by *not* destructuring `theme` from `this.props` but instead referring to it as `this.props.theme` when setting the `className` on the `<Input />` component.