### PR TITLE
Pass theme down to list item child components for correct classnames

### DIFF
--- a/components/list/ListItemActions.js
+++ b/components/list/ListItemActions.js
@@ -11,7 +11,7 @@ const factory = (ListItemAction) => {
 
     return (
       <span className={theme[type]}>
-        {validChildren.map((action, i) => <ListItemAction key={i} action={action} />)}
+        {validChildren.map((action, i) => <ListItemAction key={i} theme={theme} action={action} />)}
       </span>
     );
   };

--- a/components/list/ListItemContent.js
+++ b/components/list/ListItemContent.js
@@ -37,8 +37,8 @@ const factory = (ListItemText) => {
 
       return (
         <span className={className}>
-          {caption && <ListItemText primary>{caption}</ListItemText>}
-          {legend && <ListItemText>{legend}</ListItemText>}
+          {caption && <ListItemText theme={theme} primary>{caption}</ListItemText>}
+          {legend && <ListItemText theme={theme}>{legend}</ListItemText>}
           {children}
         </span>
       );

--- a/components/list/ListItemLayout.js
+++ b/components/list/ListItemLayout.js
@@ -23,14 +23,14 @@ const factory = (Avatar, ListItemContent, ListItemActions) => {
       props.rightIcon && <FontIcon value={props.rightIcon} key='rightIcon'/>,
       ...props.rightActions
     ];
-    const content = props.itemContent || <ListItemContent caption={props.caption} legend={props.legend} />;
+    const content = props.itemContent || <ListItemContent theme={props.theme} caption={props.caption} legend={props.legend} />;
     const emptyActions = (item) => !item[0] && !item[1] && !item[2];
 
     return (
       <span className={className}>
-        {!emptyActions(leftActions) > 0 && <ListItemActions type='left'>{leftActions}</ListItemActions>}
+        {!emptyActions(leftActions) > 0 && <ListItemActions type='left' theme={props.theme}>{leftActions}</ListItemActions>}
         {content}
-        {!emptyActions(rightActions) > 0 && <ListItemActions type='right'>{rightActions}</ListItemActions>}
+        {!emptyActions(rightActions) > 0 && <ListItemActions type='right' theme={props.theme}>{rightActions}</ListItemActions>}
       </span>
     );
   };


### PR DESCRIPTION
See #668 

This allows theming the `<ListItemContent />`, `<ListItemText />`, and `<ListItemAction />` components from the theme passed into the parent `<ListItem />`, using the `.itemContextRoot`, `.itemText`, and `.itemAction` classes.