### PR TITLE
Promote ripple component to its own composite layer only when it is active

### DIFF
--- a/components/ripple/Ripple.js
+++ b/components/ripple/Ripple.js
@@ -73,6 +73,9 @@ const rippleFactory = (options = {}) => {
       handleEnd = () => {
         document.removeEventListener(this.touch ? 'touchend' : 'mouseup', this.handleEnd);
         this.setState({active: false});
+        setTimeout(nil => {
+            this.setState({ visible: false });
+        }, 1000);
       };
 
       start = ({pageX, pageY}, touch = false) => {
@@ -80,7 +83,7 @@ const rippleFactory = (options = {}) => {
           this.touch = touch;
           document.addEventListener(this.touch ? 'touchend' : 'mouseup', this.handleEnd);
           const {top, left, width} = this._getDescriptor(pageX, pageY);
-          this.setState({active: false, restarting: true, top, left, width}, () => {
+          this.setState({active: false, restarting: true, visible: true, top, left, width}, () => {
             this.refs.ripple.offsetWidth;  //eslint-disable-line no-unused-expressions
             this.setState({active: true, restarting: false});
           });
@@ -125,6 +128,10 @@ const rippleFactory = (options = {}) => {
             [this.props.theme.rippleRestarting]: this.state.restarting
           }, className);
 
+          const rippleWrapperClassName = classnames({
+              [this.props.theme.visible]: this.state.visible,
+          }, this.props.theme.rippleWrapper);
+
           const { left, top, width } = this.state;
           const scale = this.state.restarting ? 0 : 1;
           const rippleStyle = prefixer({
@@ -134,7 +141,7 @@ const rippleFactory = (options = {}) => {
           return (
             <ComposedComponent {...other} onMouseDown={this.handleMouseDown}>
               {children ? children : null}
-              <span data-react-toolbox='ripple' className={this.props.theme.rippleWrapper} {...props}>
+              <span data-react-toolbox='ripple' className={rippleWrapperClassName} {...props}>
                 <span ref='ripple' role='ripple' className={rippleClassName} style={rippleStyle} />
               </span>
             </ComposedComponent>

--- a/components/ripple/theme.scss
+++ b/components/ripple/theme.scss
@@ -22,6 +22,10 @@
   left: 0;
   z-index: $z-index-normal;
   pointer-events: none;
+
+  &:not(.visible) {
+    display: none !important;
+  }
 }
 
 .ripple {


### PR DESCRIPTION
Currently, IconButtons are being rendered on their own composite layer because RippleComponent is in the render tree even though it's invisible. This is a problem because if you have several hundreds of instances, scrolling becomes janky. Therefore, we should exclude it from the render tree via `display: none` and only show it when the user clicks on the button.

**Before:**
![screen shot 2016-07-26 at 4 58 31 pm](https://cloud.githubusercontent.com/assets/406074/17155369/d0657d8c-5352-11e6-8ab5-ddf0f94a0dd6.png)

**After:**
![screen shot 2016-07-26 at 4 58 48 pm](https://cloud.githubusercontent.com/assets/406074/17155370/d071e284-5352-11e6-9b52-5841989261f3.png)
