### PR TITLE
Add required polyfills for IE10.

### DIFF
--- a/components/utils/polyfills.js
+++ b/components/utils/polyfills.js
@@ -1,5 +1,7 @@
 import 'core-js/fn/array/from';
 import 'core-js/fn/array/iterator';
+import 'core-js/fn/array/find-index';
 import 'core-js/fn/map';
 import 'core-js/fn/string/starts-with';
+import 'core-js/fn/string/includes';
 import 'core-js/fn/symbol';


### PR DESCRIPTION
Two missing polyfills for recent code (I assume) which breaks IE10 compatibility.

In IE10, I still get an error `Unable to get property 'direction' of undefined or null reference` which I'll try to fix in another Pull Request!