### PR TITLE
Added viewBox attr to svg element of circular ProgressBar to allow custom sizing

### DIFF
--- a/components/progress_bar/ProgressBar.js
+++ b/components/progress_bar/ProgressBar.js
@@ -62,7 +62,7 @@ class ProgressBar extends Component {
 
   renderCircular () {
     return (
-      <svg className={this.props.theme.circle}>
+      <svg className={this.props.theme.circle} viewBox="0 0 60 60">
         <circle className={this.props.theme.path} style={this.circularStyle()} cx='30' cy='30' r='25' />
       </svg>
     );

--- a/lib/progress_bar/ProgressBar.js
+++ b/lib/progress_bar/ProgressBar.js
@@ -73,7 +73,7 @@ var ProgressBar = function (_Component) {
     value: function renderCircular() {
       return _react2.default.createElement(
         'svg',
-        { className: this.props.theme.circle },
+        { className: this.props.theme.circle, viewBox: '0 0 60 60' },
         _react2.default.createElement('circle', { className: this.props.theme.path, style: this.circularStyle(), cx: '30', cy: '30', r: '25' })
       );
     }

--- a/spec/components/progress.js
+++ b/spec/components/progress.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ProgressBar from '../../components/progress_bar';
+import style from '../style'
 
 const initialState = {
   progress: 0,
@@ -47,6 +48,8 @@ class ProgressBarTest extends React.Component {
         <ProgressBar mode='indeterminate'/>
         <p style={{margin: '10px auto'}}>Circular</p>
         <ProgressBar type='circular' mode='indeterminate'/>
+        <p style={{margin: '10px auto'}}>Circular with custom size</p>
+        <ProgressBar type='circular' mode='indeterminate' className={style.customSizedProgress}/>
       </section>
     );
   }

--- a/spec/style.scss
+++ b/spec/style.scss
@@ -139,3 +139,8 @@ $offset: 1.8 * $unit;
   flex-direction: column;
   flex-grow: 2;
 }
+
+.customSizedProgress {
+  width: 40px !important;
+  height: 40px !important;
+}


### PR DESCRIPTION
This should fix #284, I think.

This allows to set a custom size on a circular ProgressBar like so:

```es6
import styles from './styles.scss'
<ProgressBar type='circular' mode='indeterminate' className={styles.progressBar} />
```

```sass
.progressBar {
    width: 32px,
    height: 32px
}
```