### PR TITLE
Refactor ripple adding `multiple` option

### DIFF
--- a/components/ripple/readme.md
+++ b/components/ripple/readme.md
@@ -1,6 +1,6 @@
 # Ripple
 
-The ripple is a surface reaction that happens when the user interacts with the component. It's useful to provide feedback about a click or touch action. In React Toolbox it's implemented as an higher order component (HOC) being a requirement for the child to implement `children` and `onMouseDown` props. Also it should be placed as relative. Hiding the overflow is up to you.
+The ripple is a surface reaction that happens when the user interacts with the component. It's useful to provide feedback about a click or touch action. In React Toolbox it's implemented as an higher order component (HOC) being a requirement for the child to implement `children`, `onMouseDown` and `onTouchStart` (in case you want to support touch) props. Also it should be placed as relative. Hiding the overflow is up to you.
 
 <!-- example -->
 ```jsx
@@ -17,17 +17,31 @@ const RippleLink = Ripple({spread: 3})(Link);
 const RippleTest = () => <RippleLink href='#' theme={theme}>Test</RippleLink>;
 ```
 
-## Properties
+## Options
 
-In any component you decorate with the Ripple you'd get some additional props:
+You can pass some options to configure the default props for the ripple when decorating a component:
 
 | Name            | Type        | Default     | Description|
 |:-----|:-----|:-----|:-----|
 | `centered`      | `Boolean`   | `false`     | True in case you want a centered ripple.|
 | `className`     | `String`    | `''`        | String to customize appearance (color and opacity for example).|
-| `onRippleEnded` | `Function`  |             | Function that will be called when the ripple animation ends. |
+| `multiple`      | `Boolean`   | `true`      | If true each touch produces a different wave. If false the same wave is restarted. |
 | `spread`        | `Number`    | `2`         | Factor to indicate how much should the ripple spread under the component.|
 | `theme`         | `Object`    | `null`      | Classnames object defining the ripple style.|
+
+## Properties
+
+In any component you decorate with the Ripple you'd get some additional props namespaced with `ripple` prefix. Some of them will get the default from the options given to the ripple factory function:
+
+| Name              | Type         | Default             | Description|
+|:-----|:-----|:-----|:-----|
+| `onRippleEnded`   | `Function`  |                     | Function that will be called when the ripple animation ends. |
+| `ripple`          | `Boolean`   | `true`              | False in case you want to deactivate the ripple.|
+| `rippleCentered`  | `Boolean`   | `options.centered`  | True in case you want a centered ripple.|
+| `rippleClassName` | `String`    | `options.className` | String to customize appearance (color and opacity for example).|
+| `rippleMultiple`  | `Boolean`   | `options.multiple`  | If true each touch produces a different wave. If false the same wave is restarted. |
+| `rippleSpread`    | `Number`    | `options.spread`    | Factor to indicate how much should the ripple spread under the component.|
+| `theme`           | `Object`    | `options.theme`     | Classnames object defining the ripple style.|
 
 ## Theming
 

--- a/components/ripple/readme.md
+++ b/components/ripple/readme.md
@@ -35,7 +35,7 @@ In any component you decorate with the Ripple you'd get some additional props na
 
 | Name              | Type         | Default             | Description|
 |:-----|:-----|:-----|:-----|
-| `onRippleEnded`   | `Function`  |                     | Function that will be called when the ripple animation ends. |
+| `onRippleEnded`   | `Function`  |                     | Function that will be called when the ripple animation ends. Beware if your animation supports multiple waves this function will be called for each ended ripple. |
 | `ripple`          | `Boolean`   | `true`              | False in case you want to deactivate the ripple.|
 | `rippleCentered`  | `Boolean`   | `options.centered`  | True in case you want a centered ripple.|
 | `rippleClassName` | `String`    | `options.className` | String to customize appearance (color and opacity for example).|

--- a/components/utils/events.js
+++ b/components/utils/events.js
@@ -46,10 +46,10 @@ export default {
     return true;
   },
 
-  removeEventListenerOnTransitionEnded (element) {
+  removeEventListenerOnTransitionEnded (element, fn) {
     const eventName = transitionEventNamesFor(element);
     if (!eventName) return false;
-    element.removeEventListener(eventName, () => {});
+    element.removeEventListener(eventName, fn);
     return true;
   }
 };

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react": "^15.2.0",
     "react-addons-css-transition-group": "^15.2.0",
     "react-addons-test-utils": "^15.0.2",
+    "react-addons-update": "^15.3.0",
     "react-docgen": "^2.8.2",
     "react-dom": "^15.2.0",
     "react-transform-catch-errors": "^1.0.2",

--- a/spec/components/button.js
+++ b/spec/components/button.js
@@ -11,7 +11,7 @@ const ButtonTest = () => (
       <GithubIcon /> Github
     </Button>
     <Button icon='bookmark' label='Bookmark' accent onRippleEnded={rippleEnded} />
-    <Button icon='bookmark' label='Bookmark' raised primary />
+    <Button icon='bookmark' label='Bookmark' raised primary rippleMultiple={false} onRippleEnded={rippleEnded} />
     <Button icon='inbox' label='Inbox' flat />
     <Button icon='add' floating />
     <Button icon='add' floating primary />


### PR DESCRIPTION
Fixes #305 

This PR brings a full refactoring of the `Ripple` component and a new behavior. 

They way it used to work was by restarting the wave if it existed but now you'll have the choice of creating multiple waves. A new option `multiple` was added to the factory function and also a `rippleMultiple` property is available for decorated components. If this option is `true`, instead of restarting the wave, a new wave will be expanded. If the option is `false` you'll get the same behavior as default. 

Since the `multiple` effect is closer to the spec, it is enabled by default for all components using the ripple. Also, the ripple now supports also `onTouchStart` so it works perfectly in mobile. Also methods on the ripple has been documented for the future since they are not straightforward.