### PR TITLE
Fixes Autocomplete error when provided value prop that is not in source option while preserving value text

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -154,9 +154,9 @@ const factory = (Chip, Input) => {
    }
 
    query (key) {
-      var query_value = '';
-      if(!this.props.multiple && key) {
-        var source_value = this.source().get(key)
+      let query_value = '';
+      if (!this.props.multiple && key) {
+        const source_value = this.source().get(key);
         query_value = source_value ? source_value : key;
       }
       return query_value;

--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -154,8 +154,13 @@ const factory = (Chip, Input) => {
    }
 
    query (key) {
-     return !this.props.multiple && key ? this.source().get(key) : '';
-   }
+      var query_value = '';
+      if(!this.props.multiple && key) {
+        var source_value = this.source().get(key)
+        query_value = source_value ? source_value : key;
+      }
+      return query_value;
+    }
 
    suggestions () {
      let suggest = new Map();

--- a/lib/autocomplete/Autocomplete.js
+++ b/lib/autocomplete/Autocomplete.js
@@ -165,8 +165,13 @@ var factory = function factory(Chip, Input) {
     }, {
       key: 'query',
       value: function query(key) {
-        return !this.props.multiple && key ? this.source().get(key) : '';
+      var query_value = '';
+      if(!this.props.multiple && key) {
+        var source_value = this.source().get(key)
+        query_value = source_value ? source_value : key;
       }
+      return query_value;
+    }
     }, {
       key: 'suggestions',
       value: function suggestions() {

--- a/lib/autocomplete/Autocomplete.js
+++ b/lib/autocomplete/Autocomplete.js
@@ -165,13 +165,13 @@ var factory = function factory(Chip, Input) {
     }, {
       key: 'query',
       value: function query(key) {
-      var query_value = '';
-      if(!this.props.multiple && key) {
-        var source_value = this.source().get(key)
-        query_value = source_value ? source_value : key;
+        var query_value = '';
+        if (!this.props.multiple && key) {
+          var source_value = this.source().get(key);
+          query_value = source_value ? source_value : key;
+        }
+        return query_value;
       }
-      return query_value;
-    }
     }, {
       key: 'suggestions',
       value: function suggestions() {


### PR DESCRIPTION
Related to [PR #684](https://github.com/react-toolbox/react-toolbox/pull/684/files) but preserves value text rather than setting empty string.