### PR TITLE
Better tooltips

### DIFF
--- a/components/tooltip/index.js
+++ b/components/tooltip/index.js
@@ -1,4 +1,6 @@
-import { tooltipFactory } from './Tooltip.js';
+import tooltipFactory from './Tooltip.js';
 import theme from './theme.scss';
 
-export default tooltipFactory(theme);
+const themedTooltipFactory = (options) => tooltipFactory({ ...options, theme });
+export default tooltipFactory({ theme });
+export { themedTooltipFactory as tooltipFactory };

--- a/components/tooltip/readme.md
+++ b/components/tooltip/readme.md
@@ -1,6 +1,6 @@
 # Tooltip
 
-A Tooltip is useful to show information on hover in any kind of component. We have a component that can be used as a **decorator** for any kind of component. You just have to take into account that the overflow in the component should be visible.
+A Tooltip is useful to show information on hover in any kind of component. We have a component that can be used as a **decorator** for any kind of component. Also, it's factory function is exposed so you can create your own decorator with specific properties.
 
 <!-- example -->
 ```jsx

--- a/components/tooltip/theme.scss
+++ b/components/tooltip/theme.scss
@@ -3,14 +3,8 @@
 @import "../mixins";
 @import "./config";
 
-.tooltipWrapper {
-  position: relative;
-}
-
 .tooltip {
   position: absolute;
-  top: 100%;
-  left: 50%;
   z-index: $z-index-higher;
   display: block;
   max-width: $tooltip-max-width;
@@ -22,6 +16,7 @@
   line-height: $font-size-small;
   color: $tooltip-color;
   text-align: center;
+  pointer-events: none;
   text-transform: none;
   background: $tooltip-background;
   border-radius: $tooltip-border-radius;


### PR DESCRIPTION
There are a couple of issues with `Tooltip`:

1 - It's always rendered, no matter if it's active or not.
2 - It is rendered as a child of the decorated component. This means that if a component has a `transform` property applied or some opacity, the tooltip is affected as well.
3 - The factory function didn't allow to create Tooltips with different default properties.

With this PR Tooltips are rendered to a `Portal` so they are at the application root solving 2. Also, it takes two different state variables: one to check if it's active and another one to check if it's visible. The second one is controlled by an animation event listener so when the Tooltip is not active and its animation finished, it's removed from the DOM. This solves 1. Finally, the factory function was reviewed and now you can import it and use it to define your own Tooltips HOC with custom theme and default properties.