### PR TITLE
Fixed #696 - Button Icon/Inner Alignment

### DIFF
--- a/components/button/theme.scss
+++ b/components/button/theme.scss
@@ -31,14 +31,14 @@
   > span:not([data-react-toolbox="tooltip"]) {
     display: inline-block;
     line-height: $button-height;
-    vertical-align: middle;
+    vertical-align: top;
   }
   > svg {
     display: inline-block;
     width: 1em;
     height: $button-height;
     font-size: 120%;
-    vertical-align: middle;
+    vertical-align: top;
     fill: currentColor;
   }
   > * {
@@ -126,7 +126,7 @@
   > .icon, svg {
     font-size: $button-toggle-font-size;
     line-height: $button-height;
-    vertical-align: middle;
+    vertical-align: top;
   }
   > .rippleWrapper {
     border-radius: 50%;

--- a/spec/components/button.js
+++ b/spec/components/button.js
@@ -24,6 +24,17 @@ const ButtonTest = () => (
     <IconButton primary><GithubIcon/></IconButton>
     <Button icon='add' label='Add this' flat primary />
     <Button icon='add' label='Add this' flat disabled />
+    <h5>Icon Button Alignment</h5>
+    <p>
+      Icon Buttons should align in the vertical center, to see this we need to
+      put them next to text or highlight thier background color.
+    </p>
+    <IconButton icon='menu' style={{'background-color': 'red'}} inverse />
+    <span style={{'vertical-align': 'middle'}}>Menu</span>
+    <IconButton icon='menu' />
+    <span style={{'vertical-align': 'middle'}}>Menu</span>
+    <IconButton><GithubIcon /></IconButton>
+    <span style={{'vertical-align': 'middle'}}>Github</span>
   </section>
 );
 


### PR DESCRIPTION
## Problem

The root problem comes from the misleading way that `vertical-align: middle` operates. If you read the specific definition [on the MDN vertical-align documentation](https://developer.mozilla.org/en/docs/Web/CSS/vertical-align) it lists the following:

> Aligns the middle of the element with the baseline plus half the x-height of the parent.

Or more specifically in the W3C documentation:

> Align the vertical midpoint of the box with the **baseline of the parent box** plus half the x-height of the parent.

Under most circumstances this effectively means "midpoint-midpoint" because the items being laid out are siblings and their parent's baseline is the same. Additionally, even if your `x-height` in a particular font is different the offset is very small (1/2 the difference to be exact). 

However when we work with `inline-block` elements inside of `inline-block` elements we have slightly different behavior. The inner element (in this case the `<span>` or `<svg>`) are relying on the baseline of the button. Any additional items inside the button would align "midpoint-midpoint" with each other, but not with the container. Notice how the span inside is pushed down slightly:

![Inner span is pushed down by aligning to the parent's baseline](https://i.imgur.com/XWflsYG.png)

This produces a very unattractive look as the text next to the button is midpoint aligning to the button, but not the content inside the button:

![Improper Alignment](https://i.imgur.com/27CC1oC.png)

## Solution

The solution is to use `vertical-align: top` for the elements inside. According to the W3C documentation:

> Align the top of the aligned subtree with the top of the line box.

The **line box** is defined by the `line-height` of the buttons or the "[strut](https://www.w3.org/TR/CSS21/visudet.html#strut)" which defines the "top" appropriately for the inner line as the top of the button. The resulting span position is now centered properly:

![Centered Properly](https://i.imgur.com/EgHjDpS.png)

And the result is a well balanced alignment:

![Balanced](https://i.imgur.com/cZcRiKQ.png)

### Commit Details

* I've updated the spec to include a section for viewing vertical alignment - I wasn't sure if this is totally right but it was the only place I could think of to add it for a more "manual/visual" acceptance test.
* I couldn't see a useful way to add tests to the karma tests as this isn't really a programatically testable change, just visual.