### PR TITLE
Added ability to manually input a date into date picker

### DIFF
--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -31,6 +31,7 @@ const factory = (Input, DatePickerDialog) => {
       ]),
       maxDate: PropTypes.object,
       minDate: PropTypes.object,
+      monthFirst: PropTypes.bool,
       name: PropTypes.string,
       onChange: PropTypes.func,
       onEscKeyDown: PropTypes.func,
@@ -50,30 +51,28 @@ const factory = (Input, DatePickerDialog) => {
     static defaultProps = {
       active: false,
       locale: 'en',
-      sundayFirstDayOfWeek: false
+      sundayFirstDayOfWeek: false,
+      readonly: false
     };
 
     state = {
-      active: this.props.active
+      active: this.props.active,
+      value: Object.prototype.toString.call(this.props.value) === '[object Date]' ? this.props.value : ''
     };
 
     componentWillReceiveProps (nextProps) {
       if (this.state.active !== nextProps.active) {
         this.setState({ active: nextProps.active });
       }
+
+      if (this.props.value !== nextProps.value) {
+        this.setState({
+          value: Object.prototype.toString.call(nextProps.value) === '[object Date]' ? nextProps.value : ''
+        });
+      }
     }
 
     handleDismiss = () => {
-      this.setState({active: false});
-    };
-
-    handleInputFocus = (event) => {
-      events.pauseEvent(event);
-      this.setState({active: true});
-    };
-
-    handleInputBlur = (event) => {
-      events.pauseEvent(event);
       this.setState({active: false});
     };
 
@@ -95,14 +94,65 @@ const factory = (Input, DatePickerDialog) => {
       this.setState({active: false});
     };
 
+    handleInputChange = (value) => {
+      this.setState({
+        value
+      });
+    }
+
+    formatInputText = (value, monthFirst) => {
+      const _value = monthFirst ? this.formatMonthFirstDate(value) : value;
+
+      if (this.isValidDate(_value)) {
+        const seperator = this.getSeparator(_value);
+        const dateSplit = _value.split(seperator);
+
+        return new Date(dateSplit[2], parseInt(dateSplit[1], 10) - 1, dateSplit[0]);
+      }
+
+      return value;
+    }
+
+    isValidDate = (dateString) => {
+      // checks for format DD/MM/YY or DD-MM-YYYY or DD.MM.YYYY
+      const regexDate = /(^(((0[1-9]|1[0-9]|2[0-8])(\/|-|\.)(0[1-9]|1[012]))|((29|30|31)(\/|-|\.)(0[13578]|1[02]))|((29|30)(\/|-|\.)(0[4,6,9]|11)))(\/|-|\.)(19|[2-9][0-9])\d\d$)|(^29(\/|-|\.)02(\/|-|\.)(19|[2-9][0-9])(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)$)/;
+      return regexDate.test(dateString);
+    }
+
+    formatMonthFirstDate = (dateString) => {
+      // Changes MM/DD/YYYY to DD/MM/YYYY
+      const seperator = this.getSeparator(dateString);
+      const dateSplit = dateString.split(seperator);
+      return dateSplit[1] + seperator + dateSplit[0] + seperator + dateSplit[2];
+    }
+
+    getSeparator = (string) => {
+      if (string.indexOf('/') !== -1) return '/';
+      if (string.indexOf('-') !== -1) return '-';
+      if (string.indexOf('.') !== -1) return '.';
+      return '';
+    }
+
+    getErrorMessage = (date, monthFirst) => {
+      if (!date || Object.prototype.toString.call(date) === '[object Date]') return '';
+      const s = this.getSeparator(date) || '/';
+      if (monthFirst) {
+        return `Please enter date in MM${s}DD${s}YYYY format`;
+      }
+      return `Please enter date in DD${s}MM${s}YYYY format`;
+    }
+
     render () {
       const { active, // eslint-disable-line
-        autoOk, inputClassName, inputFormat, locale, maxDate, minDate,
+        autoOk, inputClassName, inputFormat, locale, maxDate, minDate, monthFirst,
         onEscKeyDown, onOverlayClick, readonly, sundayFirstDayOfWeek, value,
         ...others } = this.props;
+
       const finalInputFormat = inputFormat || time.formatDate;
       const date = Object.prototype.toString.call(value) === '[object Date]' ? value : undefined;
-      const formattedDate = date === undefined ? '' : finalInputFormat(value, locale);
+      const inputDate = Object.prototype.toString.call(this.state.value) === '[object Date]' ? this.state.value : this.formatInputText(this.state.value, monthFirst);
+      const formattedDate = Object.prototype.toString.call(inputDate) === '[object Date]' ? finalInputFormat(inputDate, locale) : this.state.value;
+      const errorMessage = this.getErrorMessage(inputDate, monthFirst);
 
       return (
         <div data-react-toolbox='date-picker'>
@@ -110,14 +160,13 @@ const factory = (Input, DatePickerDialog) => {
             {...others}
             className={classnames(this.props.theme.input, {[inputClassName]: inputClassName })}
             disabled={readonly}
-            error={this.props.error}
+            error={this.props.error || errorMessage}
             icon={this.props.icon}
             label={this.props.label}
             name={this.props.name}
-            onFocus={this.handleInputFocus}
             onKeyPress={this.handleInputKeyPress}
             onMouseDown={this.handleInputMouseDown}
-            readOnly
+            onChange={this.handleInputChange}
             type='text'
             value={formattedDate}
           />
@@ -130,8 +179,8 @@ const factory = (Input, DatePickerDialog) => {
             minDate={minDate}
             name={this.props.name}
             onDismiss={this.handleDismiss}
-            onEscKeyDown={onEscKeyDown}
-            onOverlayClick={onOverlayClick}
+            onEscKeyDown={onEscKeyDown || this.handleDismiss}
+            onOverlayClick={onOverlayClick || this.handleDismiss}
             onSelect={this.handleSelect}
             sundayFirstDayOfWeek={sundayFirstDayOfWeek}
             theme={this.props.theme}

--- a/components/date_picker/readme.md
+++ b/components/date_picker/readme.md
@@ -1,6 +1,6 @@
 # Date Picker
 
-A [dialog](https://www.google.com/design/spec/components/pickers.html#pickers-date-pickers) date  picker is used to select a single date. The selected day is indicated by a filled circle. The current day is indicated by a different color and type weight.
+A [dialog](https://www.google.com/design/spec/components/pickers.html#pickers-date-pickers) date  picker is used to select a single date. The selected day is indicated by a filled circle. The current day is indicated by a different color and type weight. If the input is tabbed into a date can be entered mannual in the format MM/DD/YYYY.
 
 <!-- example -->
 ```jsx
@@ -20,7 +20,7 @@ const localeExample = {
 }
 
 class DatePickerTest extends React.Component {
-  state = {date2: datetime};
+  state = {date1: datetime};
 
   handleChange = (item, value) => {
     this.setState({...this.state, [item]: value});
@@ -29,11 +29,12 @@ class DatePickerTest extends React.Component {
   render () {
     return (
       <section>
-        <DatePicker label='Birthdate' sundayFirstDayOfWeek onChange={this.handleChange.bind(this, 'date1')} value={this.state.date1} />
-        <DatePicker label='Locale (String) - Spanish' locale='es' onChange={this.handleChange.bind(this, 'date1')} value={this.state.date1} />
-        <DatePicker label='Locale (Object) - Basque' locale={localeExample} onChange={this.handleChange.bind(this, 'date1')} value={this.state.date1} />
-        <DatePicker label='Expiration date' sundayFirstDayOfWeek minDate={min_datetime} onChange={this.handleChange.bind(this, 'date2')} value={this.state.date2} />
-        <DatePicker label='Formatted date' sundayFirstDayOfWeek inputFormat={(value) => `${value.getDate()}/${value.getMonth() + 1}/${value.getFullYear()}`} onChange={this.handleChange.bind(this, 'date3')} value={this.state.date3} />
+        <DatePicker label='Birthdate' onChange={this.handleChange.bind(this, 'date1')} value={this.state.date1} />
+        <DatePicker label='Locale (String) - Spanish' locale='es' onChange={this.handleChange.bind(this, 'date2')} value={this.state.date2} />
+        <DatePicker label='Locale (Object) - Basque' locale={localeExample} onChange={this.handleChange.bind(this, 'date3')} value={this.state.date3} />
+        <DatePicker label='Expiration date' sundayFirstDayOfWeek minDate={min_datetime} onChange={this.handleChange.bind(this, 'date4')} value={this.state.date4} />
+        <DatePicker label='Formatted date' sundayFirstDayOfWeek inputFormat={(value) => `${value.getDate()}/${value.getMonth() + 1}/${value.getFullYear()}`} onChange={this.handleChange.bind(this, 'date5')} value={this.state.date5} />
+        <DatePicker label='MM/DD/YYYY Input format' monthFirst onChange={this.handleChange.bind(this, 'date6')} value={this.state.date6} />
       </section>
     );
   }
@@ -55,10 +56,11 @@ If you want to provide a theme via context, the component key is `RTDatePicker`.
 | `locale`        | `String` or `Object` | `'en'`     | Set the locale for the date picker dialog ('en','es','af','ar','be','bg','bn','bo','br','bs','ca','gl','eu','pt','it',fr'). Object is supported too (see example above). |
 | `maxDate`       | `Date`          |               | Date object with the maximum selectable date. |
 | `minDate`       | `Date`          |               | Date object with the minimum selectable date. |
+| `monthFirst`    | `bool`          |               | Changes input to accept MM/DD/YYYY instead of DD/MM/YYYY |
 | `onChange`      | `Function`      |               | Callback called when the picker value is changed.|
 | `onEscKeyDown`  | `Function`      |               | Callback called when the ESC key is pressed with the overlay active. |
 | `onOverlayClick`| `Function`      |               | Callback to be invoked when the dialog overlay is clicked.|
-| `readonly`      | `Boolean`       |               | The input element will be readonly and look like disabled.|
+| `readonly`      | `Boolean`       | `false`       | The input element will be readonly and look like disabled.|
 | `sundayFirstDayOfWeek` | `Boolean`| `false`       | Set week's first day to Sunday. Default week's first day is Monday ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Week_dates)). |
 | `value`         | `Date`          |               | Date object with the currently selected date. |
 

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -104,8 +104,8 @@ const factory = (TimePickerDialog, Input) => {
             format={format}
             name={this.props.name}
             onDismiss={this.handleDismiss}
-            onEscKeyDown={onEscKeyDown}
-            onOverlayClick={onOverlayClick}
+            onEscKeyDown={onEscKeyDown || this.handleDismiss}
+            onOverlayClick={onOverlayClick || this.handleDismiss}
             onSelect={this.handleSelect}
             theme={this.props.theme}
             value={this.props.value}

--- a/docs/app/components/layout/main/modules/examples/datepicker_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/datepicker_example_1.txt
@@ -26,28 +26,27 @@ class DatePickerTest extends React.Component {
           label='Birthdate'
           onChange={this.handleChange.bind(this, 'date1')}
           value={this.state.date1}
-          sundayFirstDayOfWeek
         />
 
         <DatePicker
           label='Locale (String) - Spanish'
           locale='es'
-          onChange={this.handleChange.bind(this, 'date1')}
-          value={this.state.date1}
+          onChange={this.handleChange.bind(this, 'date2')}
+          value={this.state.date2}
         />
 
         <DatePicker
           label='Locale (Object) - Basque'
           locale={localeExample}
-          onChange={this.handleChange.bind(this, 'date1')}
-          value={this.state.date1}
+          onChange={this.handleChange.bind(this, 'date3')}
+          value={this.state.date3}
         />
 
         <DatePicker
           label='Expiration date'
           minDate={min_datetime}
-          onChange={this.handleChange.bind(this, 'date2')}
-          value={this.state.date2}
+          onChange={this.handleChange.bind(this, 'date4')}
+          value={this.state.date4}
           sundayFirstDayOfWeek
         />
 
@@ -55,9 +54,16 @@ class DatePickerTest extends React.Component {
           label='Formatted Date'
           autoOk
           inputFormat={(value) => `${value.getDate()}/${value.getMonth() + 1}/${value.getFullYear()}`}
-          onChange={this.handleChange.bind(this, 'date3')}
-          value={this.state.date3}
+          onChange={this.handleChange.bind(this, 'date5')}
+          value={this.state.date5}
           sundayFirstDayOfWeek
+        />
+
+        <DatePicker
+          label='MM/DD/YYYY Input format'
+          onChange={this.handleChange.bind(this, 'date6')}
+          value={this.state.date6}
+          monthFirst
         />
       </section>
     );

--- a/lib/date_picker/DatePicker.js
+++ b/lib/date_picker/DatePicker.js
@@ -77,14 +77,9 @@ var factory = function factory(Input, DatePickerDialog) {
       }
 
       return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(DatePicker)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
-        active: _this.props.active
+        active: _this.props.active,
+        value: Object.prototype.toString.call(_this.props.value) === '[object Date]' ? _this.props.value : ''
       }, _this.handleDismiss = function () {
-        _this.setState({ active: false });
-      }, _this.handleInputFocus = function (event) {
-        _events2.default.pauseEvent(event);
-        _this.setState({ active: true });
-      }, _this.handleInputBlur = function (event) {
-        _events2.default.pauseEvent(event);
         _this.setState({ active: false });
       }, _this.handleInputMouseDown = function (event) {
         _events2.default.pauseEvent(event);
@@ -98,6 +93,42 @@ var factory = function factory(Input, DatePickerDialog) {
       }, _this.handleSelect = function (value, event) {
         if (_this.props.onChange) _this.props.onChange(value, event);
         _this.setState({ active: false });
+      }, _this.handleInputChange = function (value) {
+        _this.setState({
+          value: value
+        });
+      }, _this.formatInputText = function (value, monthFirst) {
+        var _value = monthFirst ? _this.formatMonthFirstDate(value) : value;
+
+        if (_this.isValidDate(_value)) {
+          var seperator = _this.getSeparator(_value);
+          var dateSplit = _value.split(seperator);
+
+          return new Date(dateSplit[2], parseInt(dateSplit[1], 10) - 1, dateSplit[0]);
+        }
+
+        return value;
+      }, _this.isValidDate = function (dateString) {
+        // checks for format DD/MM/YY or DD-MM-YYYY or DD.MM.YYYY
+        var regexDate = /(^(((0[1-9]|1[0-9]|2[0-8])(\/|-|\.)(0[1-9]|1[012]))|((29|30|31)(\/|-|\.)(0[13578]|1[02]))|((29|30)(\/|-|\.)(0[4,6,9]|11)))(\/|-|\.)(19|[2-9][0-9])\d\d$)|(^29(\/|-|\.)02(\/|-|\.)(19|[2-9][0-9])(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)$)/;
+        return regexDate.test(dateString);
+      }, _this.formatMonthFirstDate = function (dateString) {
+        // Changes MM/DD/YYYY to DD/MM/YYYY
+        var seperator = _this.getSeparator(dateString);
+        var dateSplit = dateString.split(seperator);
+        return dateSplit[1] + seperator + dateSplit[0] + seperator + dateSplit[2];
+      }, _this.getSeparator = function (string) {
+        if (string.indexOf('/') !== -1) return '/';
+        if (string.indexOf('-') !== -1) return '-';
+        if (string.indexOf('.') !== -1) return '.';
+        return '';
+      }, _this.getErrorMessage = function (date, monthFirst) {
+        if (!date || Object.prototype.toString.call(date) === '[object Date]') return '';
+        var s = _this.getSeparator(date) || '/';
+        if (monthFirst) {
+          return 'Please enter date in MM' + s + 'DD' + s + 'YYYY format';
+        }
+        return 'Please enter date in DD' + s + 'MM' + s + 'YYYY format';
       }, _temp), _possibleConstructorReturn(_this, _ret);
     }
 
@@ -106,6 +137,12 @@ var factory = function factory(Input, DatePickerDialog) {
       value: function componentWillReceiveProps(nextProps) {
         if (this.state.active !== nextProps.active) {
           this.setState({ active: nextProps.active });
+        }
+
+        if (this.props.value !== nextProps.value) {
+          this.setState({
+            value: Object.prototype.toString.call(nextProps.value) === '[object Date]' ? nextProps.value : ''
+          });
         }
       }
     }, {
@@ -119,17 +156,20 @@ var factory = function factory(Input, DatePickerDialog) {
         var locale = _props.locale;
         var maxDate = _props.maxDate;
         var minDate = _props.minDate;
+        var monthFirst = _props.monthFirst;
         var onEscKeyDown = _props.onEscKeyDown;
         var onOverlayClick = _props.onOverlayClick;
         var readonly = _props.readonly;
         var sundayFirstDayOfWeek = _props.sundayFirstDayOfWeek;
         var value = _props.value;
 
-        var others = _objectWithoutProperties(_props, ['active', 'autoOk', 'inputClassName', 'inputFormat', 'locale', 'maxDate', 'minDate', 'onEscKeyDown', 'onOverlayClick', 'readonly', 'sundayFirstDayOfWeek', 'value']);
+        var others = _objectWithoutProperties(_props, ['active', 'autoOk', 'inputClassName', 'inputFormat', 'locale', 'maxDate', 'minDate', 'monthFirst', 'onEscKeyDown', 'onOverlayClick', 'readonly', 'sundayFirstDayOfWeek', 'value']);
 
         var finalInputFormat = inputFormat || _time2.default.formatDate;
         var date = Object.prototype.toString.call(value) === '[object Date]' ? value : undefined;
-        var formattedDate = date === undefined ? '' : finalInputFormat(value, locale);
+        var inputDate = Object.prototype.toString.call(this.state.value) === '[object Date]' ? this.state.value : this.formatInputText(this.state.value, monthFirst);
+        var formattedDate = Object.prototype.toString.call(inputDate) === '[object Date]' ? finalInputFormat(inputDate, locale) : this.state.value;
+        var errorMessage = this.getErrorMessage(inputDate, monthFirst);
 
         return _react2.default.createElement(
           'div',
@@ -137,14 +177,13 @@ var factory = function factory(Input, DatePickerDialog) {
           _react2.default.createElement(Input, _extends({}, others, {
             className: (0, _classnames3.default)(this.props.theme.input, _defineProperty({}, inputClassName, inputClassName)),
             disabled: readonly,
-            error: this.props.error,
+            error: this.props.error || errorMessage,
             icon: this.props.icon,
             label: this.props.label,
             name: this.props.name,
-            onFocus: this.handleInputFocus,
             onKeyPress: this.handleInputKeyPress,
             onMouseDown: this.handleInputMouseDown,
-            readOnly: true,
+            onChange: this.handleInputChange,
             type: 'text',
             value: formattedDate
           })),
@@ -157,8 +196,8 @@ var factory = function factory(Input, DatePickerDialog) {
             minDate: minDate,
             name: this.props.name,
             onDismiss: this.handleDismiss,
-            onEscKeyDown: onEscKeyDown,
-            onOverlayClick: onOverlayClick,
+            onEscKeyDown: onEscKeyDown || this.handleDismiss,
+            onOverlayClick: onOverlayClick || this.handleDismiss,
             onSelect: this.handleSelect,
             sundayFirstDayOfWeek: sundayFirstDayOfWeek,
             theme: this.props.theme,
@@ -183,6 +222,7 @@ var factory = function factory(Input, DatePickerDialog) {
     locale: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.object]),
     maxDate: _react.PropTypes.object,
     minDate: _react.PropTypes.object,
+    monthFirst: _react.PropTypes.bool,
     name: _react.PropTypes.string,
     onChange: _react.PropTypes.func,
     onEscKeyDown: _react.PropTypes.func,
@@ -198,7 +238,8 @@ var factory = function factory(Input, DatePickerDialog) {
   DatePicker.defaultProps = {
     active: false,
     locale: 'en',
-    sundayFirstDayOfWeek: false
+    sundayFirstDayOfWeek: false,
+    readonly: false
   };
 
 

--- a/lib/tabs/Tabs.js
+++ b/lib/tabs/Tabs.js
@@ -53,7 +53,7 @@ var factory = function factory(Tab, TabContent) {
       return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Tabs)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
         pointer: {}
       }, _this.handleHeaderClick = function (event) {
-        var idx = parseInt(event.target.id);
+        var idx = parseInt(event.currentTarget.id);
         if (_this.props.onChange) _this.props.onChange(idx);
       }, _temp), _possibleConstructorReturn(_this, _ret);
     }

--- a/lib/time_picker/TimePicker.js
+++ b/lib/time_picker/TimePicker.js
@@ -136,8 +136,8 @@ var factory = function factory(TimePickerDialog, Input) {
             format: format,
             name: this.props.name,
             onDismiss: this.handleDismiss,
-            onEscKeyDown: onEscKeyDown,
-            onOverlayClick: onOverlayClick,
+            onEscKeyDown: onEscKeyDown || this.handleDismiss,
+            onOverlayClick: onOverlayClick || this.handleDismiss,
             onSelect: this.handleSelect,
             theme: this.props.theme,
             value: this.props.value


### PR DESCRIPTION
This PR adds the ability for the user to manually enter a date if they tab into the Date Picker input field (issue

It accepts the date in the format 'DD/MM/YYYY' or if passed the prop `monthFirst` it will accept 'MM/DD/YYYY. (accepts `/`, `-`, `.` as separators)

If the date isn't in the correct format, the error shows asking for the correct format.
If the date is correctly entered it changes to a proper date object.
If the user clicks onto the input the datepicker dialog opens (a PR is coming for controlling the datepicker by keyboard)

I have only used enzyme for writing tests and wasn't sure how to access a method with `react-addons-test-utils` to write tests for date format checking. However I wrote tests for the regex: http://regexr.com/3e062

Other:
Changed DatePicker and TimePicker to dismiss overlay by default on esc or overlay click.

Happy to hear any feedback.
