### PR TITLE
Remove unnecessary spread

### DIFF
--- a/docs/app/components/layout/main/modules/examples/checkbox_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/checkbox_example_1.txt
@@ -5,7 +5,7 @@ class TestCheckbox extends React.Component {
   };
 
   handleChange = (field, value) => {
-    this.setState({...this.state, [field]: value});
+    this.setState({[field]: value});
   };
 
   render () {


### PR DESCRIPTION
`setState` does a shallow merge, so there is no need to spread the existing state here