### PR TITLE
Fixes #697 - Autocomplete KeyUp enter fix

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -124,7 +124,7 @@ const factory = (Chip, Input) => {
          }
          this.setState({active: target});
        }
-       this.select(target, event);
+       this.select(event, target);
      }
 
      if (event.which === 27) ReactDOM.findDOMNode(this).querySelector('input').blur();
@@ -225,10 +225,11 @@ const factory = (Chip, Input) => {
      return valueMap;
    }
 
-   select = (event) => {
+   select = (event, target) => {
      events.pauseEvent(event);
      const values = this.values(this.props.value);
-     this.handleChange([event.target.id, ...values.keys()], event);
+     const newValue = target === void 0 ? event.target.id : target;
+     this.handleChange([newValue, ...values.keys()], event);
    };
 
    unselect (key, event) {


### PR DESCRIPTION
Fixes issue #697 by giving Autocomplete#select an optional `target` parameter so that the active selection can be passed through from `handleQueryKeyUp()`.

Tested locally, however the build scripts removed all the `.scss` and `.t.ds` files in my environment. Tried to mimic the changes I made with GitHub's editor to avoid that step.