### PR TITLE
Passes IconMenu's theme to the inner Menu.

### DIFF
--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -71,6 +71,7 @@ const factory = (IconButton, Menu) => {
             ripple={this.props.menuRipple}
             selectable={this.props.selectable}
             selected={this.props.selected}
+            theme={this.props.theme}
           >
             {this.props.children}
           </Menu>


### PR DESCRIPTION
Small change.

Tried to theme the IconMenu and found that theme wasn't being passed through. I assume that handing IconMenu's theme to the Menu inside won't cause errors.