### PR TITLE
Fixed errors for Typescript 2.0.2

### DIFF
--- a/components/app_bar/index.d.ts
+++ b/components/app_bar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface AppBarTheme {
   /**
@@ -15,11 +16,11 @@ export interface AppBarTheme {
   flat?: string;
 }
 
-interface AppBarProps extends __ReactToolbox.Props {
+interface AppBarProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Determine if the bar should have position fixed or relative.
    * @default false
@@ -36,6 +37,6 @@ interface AppBarProps extends __ReactToolbox.Props {
   theme?: AppBarTheme;
 }
 
-export class AppBar extends __React.Component<AppBarProps, {}> { }
+export class AppBar extends React.Component<AppBarProps, {}> { }
 
 export default AppBar;

--- a/components/app_bar/index.d.ts
+++ b/components/app_bar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface AppBarTheme {
   /**

--- a/components/autocomplete/index.d.ts
+++ b/components/autocomplete/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface AutocompleteTheme {
   /**
@@ -43,7 +44,7 @@ export interface AutocompleteTheme {
   values?: string;
 }
 
-interface AutocompleteProps extends __ReactToolbox.Props {
+interface AutocompleteProps extends ReactToolbox.Props {
   /**
    * Determines the opening direction. It can be auto, up or down.
    * @default auto
@@ -100,6 +101,6 @@ interface AutocompleteProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class Autocomplete extends __React.Component<AutocompleteProps, {}> { }
+export class Autocomplete extends React.Component<AutocompleteProps, {}> { }
 
 export default Autocomplete;

--- a/components/autocomplete/index.d.ts
+++ b/components/autocomplete/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface AutocompleteTheme {
   /**

--- a/components/avatar/index.d.ts
+++ b/components/avatar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface AvatarTheme {
   /**
@@ -15,11 +16,11 @@ export interface AvatarTheme {
   letter?: string;
 }
 
-interface AvatarProps extends __ReactToolbox.Props {
+interface AvatarProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Set to true if your image is not squared so it will be used as a cover for the element.
    */
@@ -27,11 +28,11 @@ interface AvatarProps extends __ReactToolbox.Props {
   /**
    * A key to identify an Icon from Material Design Icons or a custom Icon Element.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * An image source or an image element.
    */
-  image?: __React.ReactNode | string;
+  image?: React.ReactNode | string;
   /**
    * Classnames object defining the component style.
    */
@@ -42,6 +43,6 @@ interface AvatarProps extends __ReactToolbox.Props {
   title?: string;
 }
 
-export class Avatar extends __React.Component<AvatarProps, {}> { }
+export class Avatar extends React.Component<AvatarProps, {}> { }
 
 export default Avatar;

--- a/components/avatar/index.d.ts
+++ b/components/avatar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface AvatarTheme {
   /**

--- a/components/button/index.d.ts
+++ b/components/button/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ButtonTheme {
   /**
@@ -51,7 +52,7 @@ export interface ButtonTheme {
   toggle?: string;
 }
 
-interface ButtonProps extends __ReactToolbox.Props {
+interface ButtonProps extends ReactToolbox.Props {
   /**
    * Indicates if the button should have accent color.
    * @default false
@@ -60,7 +61,7 @@ interface ButtonProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, component will be disabled.
    * @default false
@@ -83,7 +84,7 @@ interface ButtonProps extends __ReactToolbox.Props {
   /**
    * Value of the icon (See Font Icon Component).
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * If true, the neutral colors are inverted. Useful to put a button over a dark background.
    */
@@ -123,7 +124,7 @@ interface ButtonProps extends __ReactToolbox.Props {
   theme?: ButtonTheme;
 }
 
-export class Button extends __React.Component<ButtonProps, {}> { }
+export class Button extends React.Component<ButtonProps, {}> { }
 
 export interface IconButtonTheme {
   /**
@@ -160,7 +161,7 @@ export interface IconButtonTheme {
   toggle?: string;
 }
 
-interface IconButtonProps extends __ReactToolbox.Props {
+interface IconButtonProps extends ReactToolbox.Props {
   /**
    * Indicates if the button should have accent color.
    * @default false
@@ -169,7 +170,7 @@ interface IconButtonProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, component will be disabled.
    * @default false
@@ -182,7 +183,7 @@ interface IconButtonProps extends __ReactToolbox.Props {
   /**
    * Value of the icon (See Font Icon Component).
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * If true, the neutral colors are inverted. Useful to put a button over a dark background.
    */
@@ -208,4 +209,4 @@ interface IconButtonProps extends __ReactToolbox.Props {
   theme?: IconButtonTheme;
 }
 
-export class IconButton extends __React.Component<IconButtonProps, {}> { }
+export class IconButton extends React.Component<IconButtonProps, {}> { }

--- a/components/button/index.d.ts
+++ b/components/button/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ButtonTheme {
   /**

--- a/components/card/index.d.ts
+++ b/components/card/index.d.ts
@@ -1,15 +1,16 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface CardTheme {
   card?: string;
   raised?: string;
 }
 
-interface CardProps extends __ReactToolbox.Props {
+interface CardProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   raised?: boolean;
   /**
    * Classnames object defining the component style.
@@ -17,24 +18,24 @@ interface CardProps extends __ReactToolbox.Props {
   theme?: CardTheme;
 }
 
-export class Card extends __React.Component<CardProps, {}> { }
+export class Card extends React.Component<CardProps, {}> { }
 
 export interface CardActionsTheme {
   cardActions?: string;
 }
 
-interface CardActionsProps extends __ReactToolbox.Props {
+interface CardActionsProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardActionsTheme;
 }
 
-export class CardActions extends __React.Component<CardActionsProps, {}> { }
+export class CardActions extends React.Component<CardActionsProps, {}> { }
 
 export interface CardMediaTheme {
   cardMedia?: string;
@@ -44,39 +45,39 @@ export interface CardMediaTheme {
   wide?: string;
 }
 
-interface CardMediaProps extends __ReactToolbox.Props {
+interface CardMediaProps extends ReactToolbox.Props {
   aspectRatio?: "wide" | "square";
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   color?: string;
   contentOverlay?: boolean;
-  image?: __React.ReactNode | string;
+  image?: React.ReactNode | string;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardMediaTheme;
 }
 
-export class CardMedia extends __React.Component<CardMediaProps, {}> { }
+export class CardMedia extends React.Component<CardMediaProps, {}> { }
 
 export interface CardTextTheme {
   cardText?: string;
 }
 
-interface CardTextProps extends __ReactToolbox.Props {
+interface CardTextProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardTextTheme;
 }
 
-export class CardText extends __React.Component<CardTextProps, {}> { }
+export class CardText extends React.Component<CardTextProps, {}> { }
 
 export interface CardTitleTheme {
   large?: string;
@@ -85,18 +86,18 @@ export interface CardTitleTheme {
   subtitle?: string;
 }
 
-interface CardTitleProps extends __ReactToolbox.Props {
-  avatar?: __React.ReactNode | string;
+interface CardTitleProps extends ReactToolbox.Props {
+  avatar?: React.ReactNode | string;
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
-  subtitle?: __React.ReactNode | string;
+  children?: React.ReactNode;
+  subtitle?: React.ReactNode | string;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardTitleTheme;
-  title?: __React.ReactNode | string;
+  title?: React.ReactNode | string;
 }
 
-export class CardTitle extends __React.Component<CardTitleProps, {}> { }
+export class CardTitle extends React.Component<CardTitleProps, {}> { }

--- a/components/card/index.d.ts
+++ b/components/card/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface CardTheme {
   card?: string;

--- a/components/checkbox/index.d.ts
+++ b/components/checkbox/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface CheckboxTheme {
   /**
@@ -31,7 +32,7 @@ export interface CheckboxTheme {
   text?: string;
 }
 
-interface CheckboxProps extends __ReactToolbox.Props {
+interface CheckboxProps extends ReactToolbox.Props {
   /**
    * Value for the checkbox, can be true or false.
    * @default false
@@ -45,7 +46,7 @@ interface CheckboxProps extends __ReactToolbox.Props {
   /**
    * Text label to attach next to the checkbox element.
    */
-  label?: __React.ReactNode | string;
+  label?: React.ReactNode | string;
   /**
    * The name of the field to set in the input checkbox.
    */
@@ -64,6 +65,6 @@ interface CheckboxProps extends __ReactToolbox.Props {
   theme?: CheckboxTheme;
 }
 
-export class Checkbox extends __React.Component<CheckboxProps, {}> { }
+export class Checkbox extends React.Component<CheckboxProps, {}> { }
 
 export default Checkbox;

--- a/components/checkbox/index.d.ts
+++ b/components/checkbox/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface CheckboxTheme {
   /**

--- a/components/chip/index.d.ts
+++ b/components/chip/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ChipTheme {
   /**
@@ -27,11 +28,11 @@ export interface ChipTheme {
   deleteX?: string;
 }
 
-interface ChipProps extends __ReactToolbox.Props {
+interface ChipProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the chip will be rendered with a delete icon.
    * @default false
@@ -47,6 +48,6 @@ interface ChipProps extends __ReactToolbox.Props {
   theme?: ChipTheme;
 }
 
-export class Chip extends __React.Component<ChipProps, {}> { }
+export class Chip extends React.Component<ChipProps, {}> { }
 
 export default Chip;

--- a/components/chip/index.d.ts
+++ b/components/chip/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ChipTheme {
   /**

--- a/components/date_picker/index.d.ts
+++ b/components/date_picker/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DatePickerTheme {
   /**

--- a/components/date_picker/index.d.ts
+++ b/components/date_picker/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DatePickerTheme {
   /**
@@ -83,7 +84,7 @@ export interface DatePickerTheme {
   yearsDisplay?: string;
 }
 
-interface DatePickerProps extends __ReactToolbox.Props {
+interface DatePickerProps extends ReactToolbox.Props {
   /**
    * Automatically selects a date upon clicking on a day
    * @default false
@@ -96,7 +97,7 @@ interface DatePickerProps extends __ReactToolbox.Props {
   /**
    * A key to identify an Icon from Material Design Icons or a custom Icon Element.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * This class will be applied to Input component of DatePicker.
    */
@@ -143,6 +144,6 @@ interface DatePickerProps extends __ReactToolbox.Props {
   value?: Date | string;
 }
 
-export class DatePicker extends __React.Component<DatePickerProps, {}> { }
+export class DatePicker extends React.Component<DatePickerProps, {}> { }
 
 export default DatePicker;

--- a/components/dialog/index.d.ts
+++ b/components/dialog/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DialogTheme {
   /**

--- a/components/dialog/index.d.ts
+++ b/components/dialog/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DialogTheme {
   /**
@@ -38,7 +39,7 @@ interface DialogActionProps {
   onClick?: Function;
 }
 
-interface DialogProps extends __ReactToolbox.Props {
+interface DialogProps extends ReactToolbox.Props {
   /**
    * A array of objects representing the buttons for the dialog navigation area. The properties will be transferred to the buttons.
    */
@@ -51,7 +52,7 @@ interface DialogProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback called when the ESC key is pressed with the overlay active.
    */
@@ -87,6 +88,6 @@ interface DialogProps extends __ReactToolbox.Props {
   type?: string;
 }
 
-export class Dialog extends __React.Component<DialogProps, {}> { }
+export class Dialog extends React.Component<DialogProps, {}> { }
 
 export default Dialog;

--- a/components/drawer/index.d.ts
+++ b/components/drawer/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DrawerTheme {
   /**
@@ -23,7 +24,7 @@ export interface DrawerTheme {
   right?: string;
 }
 
-interface DrawerProps extends __ReactToolbox.Props {
+interface DrawerProps extends ReactToolbox.Props {
   /**
    * If true, the drawer will be visible.
    * @default false
@@ -32,7 +33,7 @@ interface DrawerProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback function to be invoked when the overlay is clicked.
    */
@@ -48,6 +49,6 @@ interface DrawerProps extends __ReactToolbox.Props {
   type?: "left" | "right";
 }
 
-export class Drawer extends __React.Component<DrawerProps, {}> { }
+export class Drawer extends React.Component<DrawerProps, {}> { }
 
 export default Drawer;

--- a/components/drawer/index.d.ts
+++ b/components/drawer/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DrawerTheme {
   /**

--- a/components/dropdown/index.d.ts
+++ b/components/dropdown/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DropdownTheme {
   /**

--- a/components/dropdown/index.d.ts
+++ b/components/dropdown/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DropdownTheme {
   /**
@@ -51,7 +52,7 @@ export interface DropdownTheme {
   values?: string;
 }
 
-interface DropdownProps extends __ReactToolbox.Props {
+interface DropdownProps extends ReactToolbox.Props {
   /**
    * If true the dropdown will preselect the first item if the supplied value matches none of the options' values.
    * @default true
@@ -109,6 +110,6 @@ interface DropdownProps extends __ReactToolbox.Props {
   value?: string | number;
 }
 
-export class Dropdown extends __React.Component<DropdownProps, {}> { }
+export class Dropdown extends React.Component<DropdownProps, {}> { }
 
 export default Dropdown;

--- a/components/font_icon/index.d.ts
+++ b/components/font_icon/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 interface FontIconProps extends __ReactToolbox.Props {
   /**

--- a/components/font_icon/index.d.ts
+++ b/components/font_icon/index.d.ts
@@ -1,16 +1,17 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
-interface FontIconProps extends __ReactToolbox.Props {
+interface FontIconProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * The key string for the icon you want be displayed.
    */
-  value?: __React.ReactNode | string;
+  value?: React.ReactNode | string;
 }
 
-export class FontIcon extends __React.Component<FontIconProps, {}> { }
+export class FontIcon extends React.Component<FontIconProps, {}> { }
 
 export default FontIcon;

--- a/components/input/index.d.ts
+++ b/components/input/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface InputTheme {
   /**
@@ -51,11 +52,11 @@ export interface InputTheme {
   withIcon?: string;
 }
 
-interface InputProps extends __ReactToolbox.Props {
+interface InputProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, component will be disabled.
    * @default false
@@ -77,7 +78,7 @@ interface InputProps extends __ReactToolbox.Props {
   /**
    * Name of an icon to use as a label for the input.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * The text string to use for the floating label element.
    */
@@ -130,6 +131,6 @@ interface InputProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class Input extends __React.Component<InputProps, {}> { }
+export class Input extends React.Component<InputProps, {}> { }
 
 export default Input;

--- a/components/input/index.d.ts
+++ b/components/input/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface InputTheme {
   /**

--- a/components/layout/index.d.ts
+++ b/components/layout/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface LayoutTheme {
   /**

--- a/components/layout/index.d.ts
+++ b/components/layout/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface LayoutTheme {
   /**
@@ -7,7 +8,7 @@ export interface LayoutTheme {
   layout?: string;
 }
 
-interface LayoutProps extends __ReactToolbox.Props {
+interface LayoutProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
@@ -18,7 +19,7 @@ interface LayoutProps extends __ReactToolbox.Props {
   theme?: LayoutTheme;
 }
 
-export class Layout extends __React.Component<LayoutProps, {}> { }
+export class Layout extends React.Component<LayoutProps, {}> { }
 
 export interface NavDrawerTheme {
   /**
@@ -75,7 +76,7 @@ export interface NavDrawerTheme {
   xxxlPermangent?: string;
 }
 
-interface NavDrawerProps extends __ReactToolbox.Props {
+interface NavDrawerProps extends ReactToolbox.Props {
   /**
    * If true, the drawer will be shown as an overlay.
    * @default false
@@ -84,7 +85,7 @@ interface NavDrawerProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback function to be invoked when the overlay is clicked.
    */
@@ -114,7 +115,7 @@ interface NavDrawerProps extends __ReactToolbox.Props {
   width?: "normal" | "wide";
 }
 
-export class NavDrawer extends __React.Component<NavDrawerProps, {}> { }
+export class NavDrawer extends React.Component<NavDrawerProps, {}> { }
 
 export interface PanelTheme {
   /**
@@ -127,11 +128,11 @@ export interface PanelTheme {
   scrollY?: string;
 }
 
-interface PanelProps extends __ReactToolbox.Props {
+interface PanelProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the panel will vertically scroll all content.
    * @default false
@@ -143,7 +144,7 @@ interface PanelProps extends __ReactToolbox.Props {
   theme?: PanelTheme;
 }
 
-export class Panel extends __React.Component<PanelProps, {}> { }
+export class Panel extends React.Component<PanelProps, {}> { }
 
 export interface SidebarTheme {
   /**
@@ -164,11 +165,11 @@ export interface SidebarTheme {
   sidebarContent?: string;
 }
 
-interface SidebarProps extends __ReactToolbox.Props {
+interface SidebarProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the sidebar will be pinned open.
    * @default false
@@ -190,4 +191,4 @@ interface SidebarProps extends __ReactToolbox.Props {
   width?: number; // 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 25 | 33 | 50 | 66 | 75 | 100;
 }
 
-export class Sidebar extends __React.Component<SidebarProps, {}> { }
+export class Sidebar extends React.Component<SidebarProps, {}> { }

--- a/components/link/index.d.ts
+++ b/components/link/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface LinkTheme {
   /**
@@ -15,7 +16,7 @@ export interface LinkTheme {
   link?: string;
 }
 
-interface LinkProps extends __ReactToolbox.Props {
+interface LinkProps extends ReactToolbox.Props {
   /**
    * If true, adds active style to link.
    * @default false
@@ -24,7 +25,7 @@ interface LinkProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Sets a count number.
    */
@@ -36,7 +37,7 @@ interface LinkProps extends __ReactToolbox.Props {
   /**
    * An icon key string to include a FontIcon component in front of the text.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * The text string used for the text content of the link.
    */
@@ -47,4 +48,4 @@ interface LinkProps extends __ReactToolbox.Props {
   theme?: LinkTheme;
 }
 
-export class Link extends __React.Component<LinkProps, {}> { }
+export class Link extends React.Component<LinkProps, {}> { }

--- a/components/link/index.d.ts
+++ b/components/link/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface LinkTheme {
   /**

--- a/components/list/index.d.ts
+++ b/components/list/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ListTheme {
   /**
@@ -7,11 +8,11 @@ export interface ListTheme {
   list?: string;
 }
 
-interface ListProps extends __ReactToolbox.Props {
+interface ListProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, each element in the list will have a ripple effect on click
    * @default false
@@ -28,7 +29,7 @@ interface ListProps extends __ReactToolbox.Props {
   theme?: ListTheme;
 }
 
-export class List extends __React.Component<ListProps, {}> { }
+export class List extends React.Component<ListProps, {}> { }
 
 export interface ListCheckboxTheme {
   /**
@@ -65,7 +66,7 @@ export interface ListCheckboxTheme {
   primary?: string;
 }
 
-interface ListCheckboxProps extends __ReactToolbox.Props {
+interface ListCheckboxProps extends ReactToolbox.Props {
   /**
    * Main text of the item. Required.
    */
@@ -106,7 +107,7 @@ interface ListCheckboxProps extends __ReactToolbox.Props {
   theme?: ListCheckboxTheme;
 }
 
-export class ListCheckbox extends __React.Component<ListCheckboxProps, {}> { }
+export class ListCheckbox extends React.Component<ListCheckboxProps, {}> { }
 
 export interface ListDividerTheme {
   /**
@@ -119,7 +120,7 @@ export interface ListDividerTheme {
   inset?: string;
 }
 
-interface ListDividerProps extends __ReactToolbox.Props {
+interface ListDividerProps extends ReactToolbox.Props {
   /**
    * If true, will leave a space at the left side.
    */
@@ -130,7 +131,7 @@ interface ListDividerProps extends __ReactToolbox.Props {
   theme?: ListDividerTheme;
 }
 
-export class ListDivider extends __React.Component<ListDivider, {}> { }
+export class ListDivider extends React.Component<ListDivider, {}> { }
 
 export interface ListItemTheme {
   /**
@@ -179,11 +180,11 @@ export interface ListItemTheme {
   selectable?: string;
 }
 
-interface ListItemProps extends __ReactToolbox.Props {
+interface ListItemProps extends ReactToolbox.Props {
   /**
    * A string URL to specify an avatar in the left side of the item.
    */
-  avatar?: __React.ReactNode | string;
+  avatar?: React.ReactNode | string;
   /**
    * Main text of the item.
    */
@@ -191,7 +192,7 @@ interface ListItemProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the item is displayed as disabled and is not clickable.
    * @default false
@@ -200,15 +201,15 @@ interface ListItemProps extends __ReactToolbox.Props {
   /**
    * An element that will be displayed as the item. If set, this will override caption and legend.
    */
-  itemContent?: __React.ReactNode;
+  itemContent?: React.ReactNode;
   /**
    * A list of elements that are placed on the left side of the item and after the avatar attribute.
    */
-  leftActions?: __React.ReactNode;
+  leftActions?: React.ReactNode;
   /**
    * A string key of a font icon or element to display an icon in the left side of the item.
    */
-  leftIcon?: __React.ReactNode | string;
+  leftIcon?: React.ReactNode | string;
   /**
    * Secondary text to display under the caption.
    */
@@ -216,11 +217,11 @@ interface ListItemProps extends __ReactToolbox.Props {
   /**
    * A list of elements that are placed on the right side of the item and after the rightIcon attribute.
    */
-  rightActions?: __React.ReactNode;
+  rightActions?: React.ReactNode;
   /**
    * The same as the leftIcon but in this case the icon is displayed in the right side.
    */
-  rightIcon?: __React.ReactNode | string;
+  rightIcon?: React.ReactNode | string;
   /**
    * If true, the item displays a ripple effect on click. By default it's inherited from the parent element.
    */
@@ -241,7 +242,7 @@ interface ListItemProps extends __ReactToolbox.Props {
   to?: string;
 }
 
-export class ListItem extends __React.Component<ListItemProps, {}> { }
+export class ListItem extends React.Component<ListItemProps, {}> { }
 
 export interface ListSubHeaderTheme {
   /**
@@ -250,7 +251,7 @@ export interface ListSubHeaderTheme {
   subheader?: string;
 }
 
-interface ListSubHeaderProps extends __ReactToolbox.Props {
+interface ListSubHeaderProps extends ReactToolbox.Props {
   /**
    * Text that will be displayed.
    */
@@ -261,4 +262,4 @@ interface ListSubHeaderProps extends __ReactToolbox.Props {
   theme?: ListSubHeaderTheme;
 }
 
-export class ListSubHeader extends __React.Component<ListSubHeaderProps, {}> { }
+export class ListSubHeader extends React.Component<ListSubHeaderProps, {}> { }

--- a/components/list/index.d.ts
+++ b/components/list/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ListTheme {
   /**

--- a/components/menu/index.d.ts
+++ b/components/menu/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface MenuTheme {
   /**

--- a/components/menu/index.d.ts
+++ b/components/menu/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface MenuTheme {
   /**
@@ -43,7 +44,7 @@ export interface MenuTheme {
   topRight?: string;
 }
 
-interface MenuProps extends __ReactToolbox.Props {
+interface MenuProps extends ReactToolbox.Props {
   /**
    * If true, the menu will be displayed as opened by default.
    * @default false
@@ -52,7 +53,7 @@ interface MenuProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback that will be called when the menu is being hidden.
    */
@@ -95,7 +96,7 @@ interface MenuProps extends __ReactToolbox.Props {
   theme?: MenuTheme;
 }
 
-export class Menu extends __React.Component<MenuProps, {}> { }
+export class Menu extends React.Component<MenuProps, {}> { }
 
 export interface IconMenuTheme {
   /**
@@ -108,16 +109,16 @@ export interface IconMenuTheme {
   iconMenu?: string;
 }
 
-interface IconMenuProps extends __ReactToolbox.Props {
+interface IconMenuProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Icon font key string or Element to display the opener icon.
    * @default more_vert
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * If true, the icon will show a ripple when is clicked.
    * @default true
@@ -160,7 +161,7 @@ interface IconMenuProps extends __ReactToolbox.Props {
   theme?: IconMenuTheme;
 }
 
-export class IconMenu extends __React.Component<IconMenuProps, {}> { }
+export class IconMenu extends React.Component<IconMenuProps, {}> { }
 
 export interface MenuDividerTheme {
   /**
@@ -169,14 +170,14 @@ export interface MenuDividerTheme {
   menuDivider?: string;
 }
 
-interface MenuDividerProps extends __ReactToolbox.Props {
+interface MenuDividerProps extends ReactToolbox.Props {
   /**
    * Classnames object defining the component style.
    */
   theme?: MenuDividerTheme;
 }
 
-export class MenuDivider extends __React.Component<MenuDividerProps, {}> { }
+export class MenuDivider extends React.Component<MenuDividerProps, {}> { }
 
 export interface MenuItemTheme {
   /**
@@ -205,7 +206,7 @@ export interface MenuItemTheme {
   shortcut?: string;
 }
 
-interface MenuItemProps extends __ReactToolbox.Props {
+interface MenuItemProps extends ReactToolbox.Props {
   /**
    * The text to include in the menu item. Required.
    */
@@ -213,7 +214,7 @@ interface MenuItemProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the item will be displayed as disabled and is not selectable.
    * @default false
@@ -222,7 +223,7 @@ interface MenuItemProps extends __ReactToolbox.Props {
   /**
    * Icon font key string or Element to display in the right side of the option.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * Transferred from the Menu component for selectable menus. Indicates if it's the current active option.
    * @default false
@@ -238,4 +239,4 @@ interface MenuItemProps extends __ReactToolbox.Props {
   theme?: MenuItemTheme;
 }
 
-export class MenuItem extends __React.Component<MenuItemProps, {}> { }
+export class MenuItem extends React.Component<MenuItemProps, {}> { }

--- a/components/navigation/index.d.ts
+++ b/components/navigation/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface NavigationTheme {
   /**

--- a/components/navigation/index.d.ts
+++ b/components/navigation/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface NavigationTheme {
   /**
@@ -19,7 +20,7 @@ export interface NavigationTheme {
   vertical?: string;
 }
 
-interface NavigationProps extends __ReactToolbox.Props {
+interface NavigationProps extends ReactToolbox.Props {
   /**
    * Array of objects that will be represented as <Button/> so the keys will be transferred as properties the Button Component.
    */
@@ -27,7 +28,7 @@ interface NavigationProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Array of objects similar to actions but that will be rendered as <Link/> component definition.
    */
@@ -43,4 +44,4 @@ interface NavigationProps extends __ReactToolbox.Props {
   type?: "vertical" | "horizontal";
 }
 
-export class Navigation extends __React.Component<NavigationProps, {}> { }
+export class Navigation extends React.Component<NavigationProps, {}> { }

--- a/components/progress_bar/index.d.ts
+++ b/components/progress_bar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ProgressBarTheme {
   /**

--- a/components/progress_bar/index.d.ts
+++ b/components/progress_bar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ProgressBarTheme {
   /**
@@ -35,7 +36,7 @@ export interface ProgressBarTheme {
   value?: string;
 }
 
-interface ProgressBarProps extends __ReactToolbox.Props {
+interface ProgressBarProps extends ReactToolbox.Props {
   /**
    * Value of a secondary progress bar useful for buffering.
    * @default 0
@@ -77,6 +78,6 @@ interface ProgressBarProps extends __ReactToolbox.Props {
   value?: number;
 }
 
-export class ProgressBar extends __React.Component<ProgressBarProps, {}> { }
+export class ProgressBar extends React.Component<ProgressBarProps, {}> { }
 
 export default ProgressBar;

--- a/components/radio/index.d.ts
+++ b/components/radio/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 interface RadioGroupProps extends __ReactToolbox.Props {
   /**

--- a/components/radio/index.d.ts
+++ b/components/radio/index.d.ts
@@ -1,10 +1,11 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
-interface RadioGroupProps extends __ReactToolbox.Props {
+interface RadioGroupProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the group will be displayed as disabled.
    * @default false
@@ -24,7 +25,7 @@ interface RadioGroupProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class RadioGroup extends __React.Component<RadioGroupProps, {}> { }
+export class RadioGroup extends React.Component<RadioGroupProps, {}> { }
 
 export interface RadioButtonTheme {
   /**
@@ -57,7 +58,7 @@ export interface RadioButtonTheme {
   text?: string;
 }
 
-interface RadioButtonProps extends __ReactToolbox.Props {
+interface RadioButtonProps extends ReactToolbox.Props {
   /**
    * If true, the input element will be selected by default. Transferred from the parent.
    * @default false
@@ -71,7 +72,7 @@ interface RadioButtonProps extends __ReactToolbox.Props {
   /**
    * Label for the radio button.
    */
-  label?: __React.ReactNode | string;
+  label?: React.ReactNode | string;
   /**
    * Name for the input element.
    */
@@ -98,4 +99,4 @@ interface RadioButtonProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class RadioButton extends __React.Component<RadioButtonProps, {}> { }
+export class RadioButton extends React.Component<RadioButtonProps, {}> { }

--- a/components/ripple/index.d.ts
+++ b/components/ripple/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface RippleTheme {
   /**

--- a/components/ripple/index.d.ts
+++ b/components/ripple/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface RippleTheme {
   /**
@@ -23,7 +24,7 @@ interface RippleProps {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * True in case you want a centered ripple.
    * @default false
@@ -44,6 +45,6 @@ interface RippleProps {
   theme?: RippleTheme;
 }
 
-export class Ripple extends __React.Component<RippleProps, {}> { }
+export class Ripple extends React.Component<RippleProps, {}> { }
 
 export default Ripple;

--- a/components/slider/index.d.ts
+++ b/components/slider/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface SliderTheme {
   /**

--- a/components/slider/index.d.ts
+++ b/components/slider/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface SliderTheme {
   /**
@@ -55,7 +56,7 @@ export interface SliderTheme {
   snaps?: string;
 }
 
-interface SliderProps extends __ReactToolbox.Props {
+interface SliderProps extends ReactToolbox.Props {
   /**
    * If true, an input is shown and the user can set the slider from keyboard value.
    * @default false
@@ -101,6 +102,6 @@ interface SliderProps extends __ReactToolbox.Props {
   value?: number;
 }
 
-export class Slider extends __React.Component<SliderProps, {}> { }
+export class Slider extends React.Component<SliderProps, {}> { }
 
 export default Slider;

--- a/components/snackbar/index.d.ts
+++ b/components/snackbar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface SnackbarTheme {
   /**
@@ -35,7 +36,7 @@ export interface SnackbarTheme {
   warning?: string;
 }
 
-interface SnackbarProps extends __ReactToolbox.Props {
+interface SnackbarProps extends ReactToolbox.Props {
   /**
    * Label for the action component inside the Snackbar.
    */
@@ -48,7 +49,7 @@ interface SnackbarProps extends __ReactToolbox.Props {
   /**
    * String key for an icon or Element which will be displayed in left side of the snackbar.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * Text to display in the content. Required.
    */
@@ -71,6 +72,6 @@ interface SnackbarProps extends __ReactToolbox.Props {
   type?: "accept" | "cancel" | "warning";
 }
 
-export class Snackbar extends __React.Component<SnackbarProps, {}> { }
+export class Snackbar extends React.Component<SnackbarProps, {}> { }
 
 export default Snackbar;

--- a/components/snackbar/index.d.ts
+++ b/components/snackbar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface SnackbarTheme {
   /**

--- a/components/switch/index.d.ts
+++ b/components/switch/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface SwitchTheme {
   /**

--- a/components/switch/index.d.ts
+++ b/components/switch/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface SwitchTheme {
   /**
@@ -35,7 +36,7 @@ export interface SwitchTheme {
   thumb?: string;
 }
 
-interface SwitchProps extends __ReactToolbox.Props {
+interface SwitchProps extends ReactToolbox.Props {
   /**
    * If true, the switch will be enabled.
    * @default false
@@ -72,6 +73,6 @@ interface SwitchProps extends __ReactToolbox.Props {
   theme?: SwitchTheme;
 }
 
-export class Switch extends __React.Component<SwitchProps, {}> { }
+export class Switch extends React.Component<SwitchProps, {}> { }
 
 export default Switch;

--- a/components/table/index.d.ts
+++ b/components/table/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface TableTheme {
   /**
@@ -23,7 +24,7 @@ export interface TableTheme {
   table?: string;
 }
 
-interface TableProps extends __ReactToolbox.Props {
+interface TableProps extends ReactToolbox.Props {
   /**
    * If true, component will show a heading using model field names.
    * @default true
@@ -65,6 +66,6 @@ interface TableProps extends __ReactToolbox.Props {
   theme?: TableTheme;
 }
 
-export class Table extends __React.Component<TableProps, {}> { }
+export class Table extends React.Component<TableProps, {}> { }
 
 export default Table;

--- a/components/table/index.d.ts
+++ b/components/table/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface TableTheme {
   /**

--- a/components/tabs/index.d.ts
+++ b/components/tabs/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface TabsTheme {
   /**

--- a/components/tabs/index.d.ts
+++ b/components/tabs/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface TabsTheme {
   /**
@@ -23,11 +24,11 @@ export interface TabsTheme {
   tab?: string;
 }
 
-interface TabsProps extends __ReactToolbox.Props {
+interface TabsProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Disable the animation below the active tab.
    * @default false
@@ -48,7 +49,7 @@ interface TabsProps extends __ReactToolbox.Props {
   theme?: TabsTheme;
 }
 
-export class Tabs extends __React.Component<TabsProps, {}> { }
+export class Tabs extends React.Component<TabsProps, {}> { }
 
 export interface TabTheme {
   /**
@@ -69,7 +70,7 @@ export interface TabTheme {
   label?: string;
 }
 
-interface TabProps extends __ReactToolbox.Props {
+interface TabProps extends ReactToolbox.Props {
   /**
    * If true, the current component is visible.
    */
@@ -102,4 +103,4 @@ interface TabProps extends __ReactToolbox.Props {
   theme?: TabTheme;
 }
 
-export class Tab extends __React.Component<TabProps, {}> { }
+export class Tab extends React.Component<TabProps, {}> { }

--- a/components/time_picker/index.d.ts
+++ b/components/time_picker/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface TimePickerTheme {
   /**
@@ -103,7 +104,7 @@ interface TimePickerProps {
   /**
    * A key to identify an Icon from Material Design Icons or a custom Icon Element.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * This class will be applied to Input component of TimePicker.
    */
@@ -131,6 +132,6 @@ interface TimePickerProps {
   value?: Date;
 }
 
-export class TimePicker extends __React.Component<TimePickerProps, {}> { }
+export class TimePicker extends React.Component<TimePickerProps, {}> { }
 
 export default TimePicker;

--- a/components/time_picker/index.d.ts
+++ b/components/time_picker/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface TimePickerTheme {
   /**

--- a/components/tooltip/index.d.ts
+++ b/components/tooltip/index.d.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 export interface TooltipTheme {
   /**
    * Added to the tooltip element.
@@ -33,7 +34,7 @@ interface TooltipProps {
   tooltipHideOnClick?: boolean;
 }
 
-declare class TooltipComponent<P, S> extends __React.Component<P, S> {
+declare class TooltipComponent<P, S> extends React.Component<P, S> {
   props: P & TooltipProps;
 }
 
@@ -41,6 +42,6 @@ interface TooltippedComponentClass<P> extends TooltipProps {
   new (props?: P, context?: any): TooltipComponent<P, any>;
 }
 
-export function Tooltip<P>(componentClass: __React.ComponentClass<P>): TooltippedComponentClass<P>;
+export function Tooltip<P>(componentClass: React.ComponentClass<P>): TooltippedComponentClass<P>;
 
 export default Tooltip;

--- a/lib/app_bar/index.d.ts
+++ b/lib/app_bar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface AppBarTheme {
   /**
@@ -15,11 +16,11 @@ export interface AppBarTheme {
   flat?: string;
 }
 
-interface AppBarProps extends __ReactToolbox.Props {
+interface AppBarProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Determine if the bar should have position fixed or relative.
    * @default false
@@ -36,6 +37,6 @@ interface AppBarProps extends __ReactToolbox.Props {
   theme?: AppBarTheme;
 }
 
-export class AppBar extends __React.Component<AppBarProps, {}> { }
+export class AppBar extends React.Component<AppBarProps, {}> { }
 
 export default AppBar;

--- a/lib/app_bar/index.d.ts
+++ b/lib/app_bar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface AppBarTheme {
   /**

--- a/lib/autocomplete/index.d.ts
+++ b/lib/autocomplete/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface AutocompleteTheme {
   /**
@@ -43,7 +44,7 @@ export interface AutocompleteTheme {
   values?: string;
 }
 
-interface AutocompleteProps extends __ReactToolbox.Props {
+interface AutocompleteProps extends ReactToolbox.Props {
   /**
    * Determines the opening direction. It can be auto, up or down.
    * @default auto
@@ -100,6 +101,6 @@ interface AutocompleteProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class Autocomplete extends __React.Component<AutocompleteProps, {}> { }
+export class Autocomplete extends React.Component<AutocompleteProps, {}> { }
 
 export default Autocomplete;

--- a/lib/autocomplete/index.d.ts
+++ b/lib/autocomplete/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface AutocompleteTheme {
   /**

--- a/lib/avatar/index.d.ts
+++ b/lib/avatar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface AvatarTheme {
   /**
@@ -15,11 +16,11 @@ export interface AvatarTheme {
   letter?: string;
 }
 
-interface AvatarProps extends __ReactToolbox.Props {
+interface AvatarProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Set to true if your image is not squared so it will be used as a cover for the element.
    */
@@ -27,11 +28,11 @@ interface AvatarProps extends __ReactToolbox.Props {
   /**
    * A key to identify an Icon from Material Design Icons or a custom Icon Element.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * An image source or an image element.
    */
-  image?: __React.ReactNode | string;
+  image?: React.ReactNode | string;
   /**
    * Classnames object defining the component style.
    */
@@ -42,6 +43,6 @@ interface AvatarProps extends __ReactToolbox.Props {
   title?: string;
 }
 
-export class Avatar extends __React.Component<AvatarProps, {}> { }
+export class Avatar extends React.Component<AvatarProps, {}> { }
 
 export default Avatar;

--- a/lib/avatar/index.d.ts
+++ b/lib/avatar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface AvatarTheme {
   /**

--- a/lib/button/index.d.ts
+++ b/lib/button/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ButtonTheme {
   /**
@@ -51,7 +52,7 @@ export interface ButtonTheme {
   toggle?: string;
 }
 
-interface ButtonProps extends __ReactToolbox.Props {
+interface ButtonProps extends ReactToolbox.Props {
   /**
    * Indicates if the button should have accent color.
    * @default false
@@ -60,7 +61,7 @@ interface ButtonProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, component will be disabled.
    * @default false
@@ -83,7 +84,7 @@ interface ButtonProps extends __ReactToolbox.Props {
   /**
    * Value of the icon (See Font Icon Component).
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * If true, the neutral colors are inverted. Useful to put a button over a dark background.
    */
@@ -123,7 +124,7 @@ interface ButtonProps extends __ReactToolbox.Props {
   theme?: ButtonTheme;
 }
 
-export class Button extends __React.Component<ButtonProps, {}> { }
+export class Button extends React.Component<ButtonProps, {}> { }
 
 export interface IconButtonTheme {
   /**
@@ -160,7 +161,7 @@ export interface IconButtonTheme {
   toggle?: string;
 }
 
-interface IconButtonProps extends __ReactToolbox.Props {
+interface IconButtonProps extends ReactToolbox.Props {
   /**
    * Indicates if the button should have accent color.
    * @default false
@@ -169,7 +170,7 @@ interface IconButtonProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, component will be disabled.
    * @default false
@@ -182,7 +183,7 @@ interface IconButtonProps extends __ReactToolbox.Props {
   /**
    * Value of the icon (See Font Icon Component).
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * If true, the neutral colors are inverted. Useful to put a button over a dark background.
    */
@@ -208,4 +209,4 @@ interface IconButtonProps extends __ReactToolbox.Props {
   theme?: IconButtonTheme;
 }
 
-export class IconButton extends __React.Component<IconButtonProps, {}> { }
+export class IconButton extends React.Component<IconButtonProps, {}> { }

--- a/lib/button/index.d.ts
+++ b/lib/button/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ButtonTheme {
   /**

--- a/lib/card/index.d.ts
+++ b/lib/card/index.d.ts
@@ -1,15 +1,16 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface CardTheme {
   card?: string;
   raised?: string;
 }
 
-interface CardProps extends __ReactToolbox.Props {
+interface CardProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   raised?: boolean;
   /**
    * Classnames object defining the component style.
@@ -17,24 +18,24 @@ interface CardProps extends __ReactToolbox.Props {
   theme?: CardTheme;
 }
 
-export class Card extends __React.Component<CardProps, {}> { }
+export class Card extends React.Component<CardProps, {}> { }
 
 export interface CardActionsTheme {
   cardActions?: string;
 }
 
-interface CardActionsProps extends __ReactToolbox.Props {
+interface CardActionsProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardActionsTheme;
 }
 
-export class CardActions extends __React.Component<CardActionsProps, {}> { }
+export class CardActions extends React.Component<CardActionsProps, {}> { }
 
 export interface CardMediaTheme {
   cardMedia?: string;
@@ -44,39 +45,39 @@ export interface CardMediaTheme {
   wide?: string;
 }
 
-interface CardMediaProps extends __ReactToolbox.Props {
+interface CardMediaProps extends ReactToolbox.Props {
   aspectRatio?: "wide" | "square";
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   color?: string;
   contentOverlay?: boolean;
-  image?: __React.ReactNode | string;
+  image?: React.ReactNode | string;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardMediaTheme;
 }
 
-export class CardMedia extends __React.Component<CardMediaProps, {}> { }
+export class CardMedia extends React.Component<CardMediaProps, {}> { }
 
 export interface CardTextTheme {
   cardText?: string;
 }
 
-interface CardTextProps extends __ReactToolbox.Props {
+interface CardTextProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardTextTheme;
 }
 
-export class CardText extends __React.Component<CardTextProps, {}> { }
+export class CardText extends React.Component<CardTextProps, {}> { }
 
 export interface CardTitleTheme {
   large?: string;
@@ -85,18 +86,18 @@ export interface CardTitleTheme {
   subtitle?: string;
 }
 
-interface CardTitleProps extends __ReactToolbox.Props {
-  avatar?: __React.ReactNode | string;
+interface CardTitleProps extends ReactToolbox.Props {
+  avatar?: React.ReactNode | string;
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
-  subtitle?: __React.ReactNode | string;
+  children?: React.ReactNode;
+  subtitle?: React.ReactNode | string;
   /**
    * Classnames object defining the component style.
    */
   theme?: CardTitleTheme;
-  title?: __React.ReactNode | string;
+  title?: React.ReactNode | string;
 }
 
-export class CardTitle extends __React.Component<CardTitleProps, {}> { }
+export class CardTitle extends React.Component<CardTitleProps, {}> { }

--- a/lib/card/index.d.ts
+++ b/lib/card/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface CardTheme {
   card?: string;

--- a/lib/checkbox/index.d.ts
+++ b/lib/checkbox/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface CheckboxTheme {
   /**
@@ -31,7 +32,7 @@ export interface CheckboxTheme {
   text?: string;
 }
 
-interface CheckboxProps extends __ReactToolbox.Props {
+interface CheckboxProps extends ReactToolbox.Props {
   /**
    * Value for the checkbox, can be true or false.
    * @default false
@@ -45,7 +46,7 @@ interface CheckboxProps extends __ReactToolbox.Props {
   /**
    * Text label to attach next to the checkbox element.
    */
-  label?: __React.ReactNode | string;
+  label?: React.ReactNode | string;
   /**
    * The name of the field to set in the input checkbox.
    */
@@ -64,6 +65,6 @@ interface CheckboxProps extends __ReactToolbox.Props {
   theme?: CheckboxTheme;
 }
 
-export class Checkbox extends __React.Component<CheckboxProps, {}> { }
+export class Checkbox extends React.Component<CheckboxProps, {}> { }
 
 export default Checkbox;

--- a/lib/checkbox/index.d.ts
+++ b/lib/checkbox/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface CheckboxTheme {
   /**

--- a/lib/chip/index.d.ts
+++ b/lib/chip/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ChipTheme {
   /**
@@ -27,11 +28,11 @@ export interface ChipTheme {
   deleteX?: string;
 }
 
-interface ChipProps extends __ReactToolbox.Props {
+interface ChipProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the chip will be rendered with a delete icon.
    * @default false
@@ -47,6 +48,6 @@ interface ChipProps extends __ReactToolbox.Props {
   theme?: ChipTheme;
 }
 
-export class Chip extends __React.Component<ChipProps, {}> { }
+export class Chip extends React.Component<ChipProps, {}> { }
 
 export default Chip;

--- a/lib/chip/index.d.ts
+++ b/lib/chip/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ChipTheme {
   /**

--- a/lib/date_picker/index.d.ts
+++ b/lib/date_picker/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DatePickerTheme {
   /**

--- a/lib/date_picker/index.d.ts
+++ b/lib/date_picker/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DatePickerTheme {
   /**
@@ -83,7 +84,7 @@ export interface DatePickerTheme {
   yearsDisplay?: string;
 }
 
-interface DatePickerProps extends __ReactToolbox.Props {
+interface DatePickerProps extends ReactToolbox.Props {
   /**
    * Automatically selects a date upon clicking on a day
    * @default false
@@ -96,7 +97,7 @@ interface DatePickerProps extends __ReactToolbox.Props {
   /**
    * A key to identify an Icon from Material Design Icons or a custom Icon Element.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * This class will be applied to Input component of DatePicker.
    */
@@ -143,6 +144,6 @@ interface DatePickerProps extends __ReactToolbox.Props {
   value?: Date | string;
 }
 
-export class DatePicker extends __React.Component<DatePickerProps, {}> { }
+export class DatePicker extends React.Component<DatePickerProps, {}> { }
 
 export default DatePicker;

--- a/lib/dialog/index.d.ts
+++ b/lib/dialog/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DialogTheme {
   /**

--- a/lib/dialog/index.d.ts
+++ b/lib/dialog/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DialogTheme {
   /**
@@ -38,7 +39,7 @@ interface DialogActionProps {
   onClick?: Function;
 }
 
-interface DialogProps extends __ReactToolbox.Props {
+interface DialogProps extends ReactToolbox.Props {
   /**
    * A array of objects representing the buttons for the dialog navigation area. The properties will be transferred to the buttons.
    */
@@ -51,7 +52,7 @@ interface DialogProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback called when the ESC key is pressed with the overlay active.
    */
@@ -87,6 +88,6 @@ interface DialogProps extends __ReactToolbox.Props {
   type?: string;
 }
 
-export class Dialog extends __React.Component<DialogProps, {}> { }
+export class Dialog extends React.Component<DialogProps, {}> { }
 
 export default Dialog;

--- a/lib/drawer/index.d.ts
+++ b/lib/drawer/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DrawerTheme {
   /**
@@ -23,7 +24,7 @@ export interface DrawerTheme {
   right?: string;
 }
 
-interface DrawerProps extends __ReactToolbox.Props {
+interface DrawerProps extends ReactToolbox.Props {
   /**
    * If true, the drawer will be visible.
    * @default false
@@ -32,7 +33,7 @@ interface DrawerProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback function to be invoked when the overlay is clicked.
    */
@@ -48,6 +49,6 @@ interface DrawerProps extends __ReactToolbox.Props {
   type?: "left" | "right";
 }
 
-export class Drawer extends __React.Component<DrawerProps, {}> { }
+export class Drawer extends React.Component<DrawerProps, {}> { }
 
 export default Drawer;

--- a/lib/drawer/index.d.ts
+++ b/lib/drawer/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DrawerTheme {
   /**

--- a/lib/dropdown/index.d.ts
+++ b/lib/dropdown/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface DropdownTheme {
   /**

--- a/lib/dropdown/index.d.ts
+++ b/lib/dropdown/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface DropdownTheme {
   /**
@@ -51,7 +52,7 @@ export interface DropdownTheme {
   values?: string;
 }
 
-interface DropdownProps extends __ReactToolbox.Props {
+interface DropdownProps extends ReactToolbox.Props {
   /**
    * If true the dropdown will preselect the first item if the supplied value matches none of the options' values.
    * @default true
@@ -109,6 +110,6 @@ interface DropdownProps extends __ReactToolbox.Props {
   value?: string | number;
 }
 
-export class Dropdown extends __React.Component<DropdownProps, {}> { }
+export class Dropdown extends React.Component<DropdownProps, {}> { }
 
 export default Dropdown;

--- a/lib/font_icon/index.d.ts
+++ b/lib/font_icon/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 interface FontIconProps extends __ReactToolbox.Props {
   /**

--- a/lib/font_icon/index.d.ts
+++ b/lib/font_icon/index.d.ts
@@ -1,16 +1,17 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
-interface FontIconProps extends __ReactToolbox.Props {
+interface FontIconProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * The key string for the icon you want be displayed.
    */
-  value?: __React.ReactNode | string;
+  value?: React.ReactNode | string;
 }
 
-export class FontIcon extends __React.Component<FontIconProps, {}> { }
+export class FontIcon extends React.Component<FontIconProps, {}> { }
 
 export default FontIcon;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
-export declare namespace __ReactToolbox {
+import * as React from "react";
+export declare namespace ReactToolbox {
   interface Props {
     /**
      * Set a class for the root component.
@@ -48,8 +49,8 @@ export declare namespace __ReactToolbox {
     /**
      * Set inline style for the root component.
      */
-    style?: __React.CSSProperties;
+    style?: React.CSSProperties;
   }
 }
 
-export default __ReactToolbox;
+export default ReactToolbox;

--- a/lib/input/index.d.ts
+++ b/lib/input/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface InputTheme {
   /**
@@ -51,11 +52,11 @@ export interface InputTheme {
   withIcon?: string;
 }
 
-interface InputProps extends __ReactToolbox.Props {
+interface InputProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, component will be disabled.
    * @default false
@@ -77,7 +78,7 @@ interface InputProps extends __ReactToolbox.Props {
   /**
    * Name of an icon to use as a label for the input.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * The text string to use for the floating label element.
    */
@@ -130,6 +131,6 @@ interface InputProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class Input extends __React.Component<InputProps, {}> { }
+export class Input extends React.Component<InputProps, {}> { }
 
 export default Input;

--- a/lib/input/index.d.ts
+++ b/lib/input/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface InputTheme {
   /**

--- a/lib/layout/index.d.ts
+++ b/lib/layout/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface LayoutTheme {
   /**

--- a/lib/layout/index.d.ts
+++ b/lib/layout/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface LayoutTheme {
   /**
@@ -7,7 +8,7 @@ export interface LayoutTheme {
   layout?: string;
 }
 
-interface LayoutProps extends __ReactToolbox.Props {
+interface LayoutProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
@@ -18,7 +19,7 @@ interface LayoutProps extends __ReactToolbox.Props {
   theme?: LayoutTheme;
 }
 
-export class Layout extends __React.Component<LayoutProps, {}> { }
+export class Layout extends React.Component<LayoutProps, {}> { }
 
 export interface NavDrawerTheme {
   /**
@@ -75,7 +76,7 @@ export interface NavDrawerTheme {
   xxxlPermangent?: string;
 }
 
-interface NavDrawerProps extends __ReactToolbox.Props {
+interface NavDrawerProps extends ReactToolbox.Props {
   /**
    * If true, the drawer will be shown as an overlay.
    * @default false
@@ -84,7 +85,7 @@ interface NavDrawerProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback function to be invoked when the overlay is clicked.
    */
@@ -114,7 +115,7 @@ interface NavDrawerProps extends __ReactToolbox.Props {
   width?: "normal" | "wide";
 }
 
-export class NavDrawer extends __React.Component<NavDrawerProps, {}> { }
+export class NavDrawer extends React.Component<NavDrawerProps, {}> { }
 
 export interface PanelTheme {
   /**
@@ -127,11 +128,11 @@ export interface PanelTheme {
   scrollY?: string;
 }
 
-interface PanelProps extends __ReactToolbox.Props {
+interface PanelProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the panel will vertically scroll all content.
    * @default false
@@ -143,7 +144,7 @@ interface PanelProps extends __ReactToolbox.Props {
   theme?: PanelTheme;
 }
 
-export class Panel extends __React.Component<PanelProps, {}> { }
+export class Panel extends React.Component<PanelProps, {}> { }
 
 export interface SidebarTheme {
   /**
@@ -164,11 +165,11 @@ export interface SidebarTheme {
   sidebarContent?: string;
 }
 
-interface SidebarProps extends __ReactToolbox.Props {
+interface SidebarProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the sidebar will be pinned open.
    * @default false
@@ -190,4 +191,4 @@ interface SidebarProps extends __ReactToolbox.Props {
   width?: number; // 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 25 | 33 | 50 | 66 | 75 | 100;
 }
 
-export class Sidebar extends __React.Component<SidebarProps, {}> { }
+export class Sidebar extends React.Component<SidebarProps, {}> { }

--- a/lib/link/index.d.ts
+++ b/lib/link/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface LinkTheme {
   /**
@@ -15,7 +16,7 @@ export interface LinkTheme {
   link?: string;
 }
 
-interface LinkProps extends __ReactToolbox.Props {
+interface LinkProps extends ReactToolbox.Props {
   /**
    * If true, adds active style to link.
    * @default false
@@ -24,7 +25,7 @@ interface LinkProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Sets a count number.
    */
@@ -36,7 +37,7 @@ interface LinkProps extends __ReactToolbox.Props {
   /**
    * An icon key string to include a FontIcon component in front of the text.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * The text string used for the text content of the link.
    */
@@ -47,4 +48,4 @@ interface LinkProps extends __ReactToolbox.Props {
   theme?: LinkTheme;
 }
 
-export class Link extends __React.Component<LinkProps, {}> { }
+export class Link extends React.Component<LinkProps, {}> { }

--- a/lib/link/index.d.ts
+++ b/lib/link/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface LinkTheme {
   /**

--- a/lib/list/index.d.ts
+++ b/lib/list/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ListTheme {
   /**
@@ -7,11 +8,11 @@ export interface ListTheme {
   list?: string;
 }
 
-interface ListProps extends __ReactToolbox.Props {
+interface ListProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, each element in the list will have a ripple effect on click
    * @default false
@@ -28,7 +29,7 @@ interface ListProps extends __ReactToolbox.Props {
   theme?: ListTheme;
 }
 
-export class List extends __React.Component<ListProps, {}> { }
+export class List extends React.Component<ListProps, {}> { }
 
 export interface ListCheckboxTheme {
   /**
@@ -65,7 +66,7 @@ export interface ListCheckboxTheme {
   primary?: string;
 }
 
-interface ListCheckboxProps extends __ReactToolbox.Props {
+interface ListCheckboxProps extends ReactToolbox.Props {
   /**
    * Main text of the item. Required.
    */
@@ -106,7 +107,7 @@ interface ListCheckboxProps extends __ReactToolbox.Props {
   theme?: ListCheckboxTheme;
 }
 
-export class ListCheckbox extends __React.Component<ListCheckboxProps, {}> { }
+export class ListCheckbox extends React.Component<ListCheckboxProps, {}> { }
 
 export interface ListDividerTheme {
   /**
@@ -119,7 +120,7 @@ export interface ListDividerTheme {
   inset?: string;
 }
 
-interface ListDividerProps extends __ReactToolbox.Props {
+interface ListDividerProps extends ReactToolbox.Props {
   /**
    * If true, will leave a space at the left side.
    */
@@ -130,7 +131,7 @@ interface ListDividerProps extends __ReactToolbox.Props {
   theme?: ListDividerTheme;
 }
 
-export class ListDivider extends __React.Component<ListDivider, {}> { }
+export class ListDivider extends React.Component<ListDivider, {}> { }
 
 export interface ListItemTheme {
   /**
@@ -179,11 +180,11 @@ export interface ListItemTheme {
   selectable?: string;
 }
 
-interface ListItemProps extends __ReactToolbox.Props {
+interface ListItemProps extends ReactToolbox.Props {
   /**
    * A string URL to specify an avatar in the left side of the item.
    */
-  avatar?: __React.ReactNode | string;
+  avatar?: React.ReactNode | string;
   /**
    * Main text of the item.
    */
@@ -191,7 +192,7 @@ interface ListItemProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the item is displayed as disabled and is not clickable.
    * @default false
@@ -200,15 +201,15 @@ interface ListItemProps extends __ReactToolbox.Props {
   /**
    * An element that will be displayed as the item. If set, this will override caption and legend.
    */
-  itemContent?: __React.ReactNode;
+  itemContent?: React.ReactNode;
   /**
    * A list of elements that are placed on the left side of the item and after the avatar attribute.
    */
-  leftActions?: __React.ReactNode;
+  leftActions?: React.ReactNode;
   /**
    * A string key of a font icon or element to display an icon in the left side of the item.
    */
-  leftIcon?: __React.ReactNode | string;
+  leftIcon?: React.ReactNode | string;
   /**
    * Secondary text to display under the caption.
    */
@@ -216,11 +217,11 @@ interface ListItemProps extends __ReactToolbox.Props {
   /**
    * A list of elements that are placed on the right side of the item and after the rightIcon attribute.
    */
-  rightActions?: __React.ReactNode;
+  rightActions?: React.ReactNode;
   /**
    * The same as the leftIcon but in this case the icon is displayed in the right side.
    */
-  rightIcon?: __React.ReactNode | string;
+  rightIcon?: React.ReactNode | string;
   /**
    * If true, the item displays a ripple effect on click. By default it's inherited from the parent element.
    */
@@ -241,7 +242,7 @@ interface ListItemProps extends __ReactToolbox.Props {
   to?: string;
 }
 
-export class ListItem extends __React.Component<ListItemProps, {}> { }
+export class ListItem extends React.Component<ListItemProps, {}> { }
 
 export interface ListSubHeaderTheme {
   /**
@@ -250,7 +251,7 @@ export interface ListSubHeaderTheme {
   subheader?: string;
 }
 
-interface ListSubHeaderProps extends __ReactToolbox.Props {
+interface ListSubHeaderProps extends ReactToolbox.Props {
   /**
    * Text that will be displayed.
    */
@@ -261,4 +262,4 @@ interface ListSubHeaderProps extends __ReactToolbox.Props {
   theme?: ListSubHeaderTheme;
 }
 
-export class ListSubHeader extends __React.Component<ListSubHeaderProps, {}> { }
+export class ListSubHeader extends React.Component<ListSubHeaderProps, {}> { }

--- a/lib/list/index.d.ts
+++ b/lib/list/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ListTheme {
   /**

--- a/lib/menu/index.d.ts
+++ b/lib/menu/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface MenuTheme {
   /**

--- a/lib/menu/index.d.ts
+++ b/lib/menu/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface MenuTheme {
   /**
@@ -43,7 +44,7 @@ export interface MenuTheme {
   topRight?: string;
 }
 
-interface MenuProps extends __ReactToolbox.Props {
+interface MenuProps extends ReactToolbox.Props {
   /**
    * If true, the menu will be displayed as opened by default.
    * @default false
@@ -52,7 +53,7 @@ interface MenuProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Callback that will be called when the menu is being hidden.
    */
@@ -95,7 +96,7 @@ interface MenuProps extends __ReactToolbox.Props {
   theme?: MenuTheme;
 }
 
-export class Menu extends __React.Component<MenuProps, {}> { }
+export class Menu extends React.Component<MenuProps, {}> { }
 
 export interface IconMenuTheme {
   /**
@@ -108,16 +109,16 @@ export interface IconMenuTheme {
   iconMenu?: string;
 }
 
-interface IconMenuProps extends __ReactToolbox.Props {
+interface IconMenuProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Icon font key string or Element to display the opener icon.
    * @default more_vert
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * If true, the icon will show a ripple when is clicked.
    * @default true
@@ -160,7 +161,7 @@ interface IconMenuProps extends __ReactToolbox.Props {
   theme?: IconMenuTheme;
 }
 
-export class IconMenu extends __React.Component<IconMenuProps, {}> { }
+export class IconMenu extends React.Component<IconMenuProps, {}> { }
 
 export interface MenuDividerTheme {
   /**
@@ -169,14 +170,14 @@ export interface MenuDividerTheme {
   menuDivider?: string;
 }
 
-interface MenuDividerProps extends __ReactToolbox.Props {
+interface MenuDividerProps extends ReactToolbox.Props {
   /**
    * Classnames object defining the component style.
    */
   theme?: MenuDividerTheme;
 }
 
-export class MenuDivider extends __React.Component<MenuDividerProps, {}> { }
+export class MenuDivider extends React.Component<MenuDividerProps, {}> { }
 
 export interface MenuItemTheme {
   /**
@@ -205,7 +206,7 @@ export interface MenuItemTheme {
   shortcut?: string;
 }
 
-interface MenuItemProps extends __ReactToolbox.Props {
+interface MenuItemProps extends ReactToolbox.Props {
   /**
    * The text to include in the menu item. Required.
    */
@@ -213,7 +214,7 @@ interface MenuItemProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the item will be displayed as disabled and is not selectable.
    * @default false
@@ -222,7 +223,7 @@ interface MenuItemProps extends __ReactToolbox.Props {
   /**
    * Icon font key string or Element to display in the right side of the option.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * Transferred from the Menu component for selectable menus. Indicates if it's the current active option.
    * @default false
@@ -238,4 +239,4 @@ interface MenuItemProps extends __ReactToolbox.Props {
   theme?: MenuItemTheme;
 }
 
-export class MenuItem extends __React.Component<MenuItemProps, {}> { }
+export class MenuItem extends React.Component<MenuItemProps, {}> { }

--- a/lib/navigation/index.d.ts
+++ b/lib/navigation/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface NavigationTheme {
   /**

--- a/lib/navigation/index.d.ts
+++ b/lib/navigation/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface NavigationTheme {
   /**
@@ -19,7 +20,7 @@ export interface NavigationTheme {
   vertical?: string;
 }
 
-interface NavigationProps extends __ReactToolbox.Props {
+interface NavigationProps extends ReactToolbox.Props {
   /**
    * Array of objects that will be represented as <Button/> so the keys will be transferred as properties the Button Component.
    */
@@ -27,7 +28,7 @@ interface NavigationProps extends __ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Array of objects similar to actions but that will be rendered as <Link/> component definition.
    */
@@ -43,4 +44,4 @@ interface NavigationProps extends __ReactToolbox.Props {
   type?: "vertical" | "horizontal";
 }
 
-export class Navigation extends __React.Component<NavigationProps, {}> { }
+export class Navigation extends React.Component<NavigationProps, {}> { }

--- a/lib/progress_bar/index.d.ts
+++ b/lib/progress_bar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface ProgressBarTheme {
   /**

--- a/lib/progress_bar/index.d.ts
+++ b/lib/progress_bar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface ProgressBarTheme {
   /**
@@ -35,7 +36,7 @@ export interface ProgressBarTheme {
   value?: string;
 }
 
-interface ProgressBarProps extends __ReactToolbox.Props {
+interface ProgressBarProps extends ReactToolbox.Props {
   /**
    * Value of a secondary progress bar useful for buffering.
    * @default 0
@@ -77,6 +78,6 @@ interface ProgressBarProps extends __ReactToolbox.Props {
   value?: number;
 }
 
-export class ProgressBar extends __React.Component<ProgressBarProps, {}> { }
+export class ProgressBar extends React.Component<ProgressBarProps, {}> { }
 
 export default ProgressBar;

--- a/lib/radio/index.d.ts
+++ b/lib/radio/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 interface RadioGroupProps extends __ReactToolbox.Props {
   /**

--- a/lib/radio/index.d.ts
+++ b/lib/radio/index.d.ts
@@ -1,10 +1,11 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
-interface RadioGroupProps extends __ReactToolbox.Props {
+interface RadioGroupProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If true, the group will be displayed as disabled.
    * @default false
@@ -24,7 +25,7 @@ interface RadioGroupProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class RadioGroup extends __React.Component<RadioGroupProps, {}> { }
+export class RadioGroup extends React.Component<RadioGroupProps, {}> { }
 
 export interface RadioButtonTheme {
   /**
@@ -57,7 +58,7 @@ export interface RadioButtonTheme {
   text?: string;
 }
 
-interface RadioButtonProps extends __ReactToolbox.Props {
+interface RadioButtonProps extends ReactToolbox.Props {
   /**
    * If true, the input element will be selected by default. Transferred from the parent.
    * @default false
@@ -71,7 +72,7 @@ interface RadioButtonProps extends __ReactToolbox.Props {
   /**
    * Label for the radio button.
    */
-  label?: __React.ReactNode | string;
+  label?: React.ReactNode | string;
   /**
    * Name for the input element.
    */
@@ -98,4 +99,4 @@ interface RadioButtonProps extends __ReactToolbox.Props {
   value?: any;
 }
 
-export class RadioButton extends __React.Component<RadioButtonProps, {}> { }
+export class RadioButton extends React.Component<RadioButtonProps, {}> { }

--- a/lib/ripple/index.d.ts
+++ b/lib/ripple/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface RippleTheme {
   /**

--- a/lib/ripple/index.d.ts
+++ b/lib/ripple/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface RippleTheme {
   /**
@@ -23,7 +24,7 @@ interface RippleProps {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * True in case you want a centered ripple.
    * @default false
@@ -44,6 +45,6 @@ interface RippleProps {
   theme?: RippleTheme;
 }
 
-export class Ripple extends __React.Component<RippleProps, {}> { }
+export class Ripple extends React.Component<RippleProps, {}> { }
 
 export default Ripple;

--- a/lib/slider/index.d.ts
+++ b/lib/slider/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface SliderTheme {
   /**

--- a/lib/slider/index.d.ts
+++ b/lib/slider/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface SliderTheme {
   /**
@@ -55,7 +56,7 @@ export interface SliderTheme {
   snaps?: string;
 }
 
-interface SliderProps extends __ReactToolbox.Props {
+interface SliderProps extends ReactToolbox.Props {
   /**
    * If true, an input is shown and the user can set the slider from keyboard value.
    * @default false
@@ -101,6 +102,6 @@ interface SliderProps extends __ReactToolbox.Props {
   value?: number;
 }
 
-export class Slider extends __React.Component<SliderProps, {}> { }
+export class Slider extends React.Component<SliderProps, {}> { }
 
 export default Slider;

--- a/lib/snackbar/index.d.ts
+++ b/lib/snackbar/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface SnackbarTheme {
   /**
@@ -35,7 +36,7 @@ export interface SnackbarTheme {
   warning?: string;
 }
 
-interface SnackbarProps extends __ReactToolbox.Props {
+interface SnackbarProps extends ReactToolbox.Props {
   /**
    * Label for the action component inside the Snackbar.
    */
@@ -48,7 +49,7 @@ interface SnackbarProps extends __ReactToolbox.Props {
   /**
    * String key for an icon or Element which will be displayed in left side of the snackbar.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * Text to display in the content. Required.
    */
@@ -71,6 +72,6 @@ interface SnackbarProps extends __ReactToolbox.Props {
   type?: "accept" | "cancel" | "warning";
 }
 
-export class Snackbar extends __React.Component<SnackbarProps, {}> { }
+export class Snackbar extends React.Component<SnackbarProps, {}> { }
 
 export default Snackbar;

--- a/lib/snackbar/index.d.ts
+++ b/lib/snackbar/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface SnackbarTheme {
   /**

--- a/lib/switch/index.d.ts
+++ b/lib/switch/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface SwitchTheme {
   /**

--- a/lib/switch/index.d.ts
+++ b/lib/switch/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface SwitchTheme {
   /**
@@ -35,7 +36,7 @@ export interface SwitchTheme {
   thumb?: string;
 }
 
-interface SwitchProps extends __ReactToolbox.Props {
+interface SwitchProps extends ReactToolbox.Props {
   /**
    * If true, the switch will be enabled.
    * @default false
@@ -72,6 +73,6 @@ interface SwitchProps extends __ReactToolbox.Props {
   theme?: SwitchTheme;
 }
 
-export class Switch extends __React.Component<SwitchProps, {}> { }
+export class Switch extends React.Component<SwitchProps, {}> { }
 
 export default Switch;

--- a/lib/table/index.d.ts
+++ b/lib/table/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface TableTheme {
   /**
@@ -23,7 +24,7 @@ export interface TableTheme {
   table?: string;
 }
 
-interface TableProps extends __ReactToolbox.Props {
+interface TableProps extends ReactToolbox.Props {
   /**
    * If true, component will show a heading using model field names.
    * @default true
@@ -65,6 +66,6 @@ interface TableProps extends __ReactToolbox.Props {
   theme?: TableTheme;
 }
 
-export class Table extends __React.Component<TableProps, {}> { }
+export class Table extends React.Component<TableProps, {}> { }
 
 export default Table;

--- a/lib/table/index.d.ts
+++ b/lib/table/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface TableTheme {
   /**

--- a/lib/tabs/index.d.ts
+++ b/lib/tabs/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface TabsTheme {
   /**

--- a/lib/tabs/index.d.ts
+++ b/lib/tabs/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface TabsTheme {
   /**
@@ -23,11 +24,11 @@ export interface TabsTheme {
   tab?: string;
 }
 
-interface TabsProps extends __ReactToolbox.Props {
+interface TabsProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: __React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Disable the animation below the active tab.
    * @default false
@@ -48,7 +49,7 @@ interface TabsProps extends __ReactToolbox.Props {
   theme?: TabsTheme;
 }
 
-export class Tabs extends __React.Component<TabsProps, {}> { }
+export class Tabs extends React.Component<TabsProps, {}> { }
 
 export interface TabTheme {
   /**
@@ -69,7 +70,7 @@ export interface TabTheme {
   label?: string;
 }
 
-interface TabProps extends __ReactToolbox.Props {
+interface TabProps extends ReactToolbox.Props {
   /**
    * If true, the current component is visible.
    */
@@ -102,4 +103,4 @@ interface TabProps extends __ReactToolbox.Props {
   theme?: TabTheme;
 }
 
-export class Tab extends __React.Component<TabProps, {}> { }
+export class Tab extends React.Component<TabProps, {}> { }

--- a/lib/time_picker/index.d.ts
+++ b/lib/time_picker/index.d.ts
@@ -1,4 +1,5 @@
-import __ReactToolbox from "../index";
+import * as React from "react";
+import ReactToolbox from "../index";
 
 export interface TimePickerTheme {
   /**
@@ -103,7 +104,7 @@ interface TimePickerProps {
   /**
    * A key to identify an Icon from Material Design Icons or a custom Icon Element.
    */
-  icon?: __React.ReactNode | string;
+  icon?: React.ReactNode | string;
   /**
    * This class will be applied to Input component of TimePicker.
    */
@@ -131,6 +132,6 @@ interface TimePickerProps {
   value?: Date;
 }
 
-export class TimePicker extends __React.Component<TimePickerProps, {}> { }
+export class TimePicker extends React.Component<TimePickerProps, {}> { }
 
 export default TimePicker;

--- a/lib/time_picker/index.d.ts
+++ b/lib/time_picker/index.d.ts
@@ -1,4 +1,4 @@
-import __ReactToolbox from "../index.d.ts";
+import __ReactToolbox from "../index";
 
 export interface TimePickerTheme {
   /**

--- a/lib/tooltip/index.d.ts
+++ b/lib/tooltip/index.d.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 export interface TooltipTheme {
   /**
    * Added to the tooltip element.
@@ -33,7 +34,7 @@ interface TooltipProps {
   tooltipHideOnClick?: boolean;
 }
 
-declare class TooltipComponent<P, S> extends __React.Component<P, S> {
+declare class TooltipComponent<P, S> extends React.Component<P, S> {
   props: P & TooltipProps;
 }
 
@@ -41,6 +42,6 @@ interface TooltippedComponentClass<P> extends TooltipProps {
   new (props?: P, context?: any): TooltipComponent<P, any>;
 }
 
-export function Tooltip<P>(componentClass: __React.ComponentClass<P>): TooltippedComponentClass<P>;
+export function Tooltip<P>(componentClass: React.ComponentClass<P>): TooltippedComponentClass<P>;
 
 export default Tooltip;


### PR DESCRIPTION
The latest RC of Typescript gave errors for having file extensions in the imports.
Should still work with older versions of Typescript but haven't tried anything older than the 2.0.0 beta.