### PR TITLE
Fix table borders (Issue #476)

### DIFF
--- a/components/table/theme.scss
+++ b/components/table/theme.scss
@@ -8,10 +8,10 @@
   font-size: $font-size-tiny;
   color: $table-text-color;
   text-align: left;
+  border-spacing: 0;
   tr {
     height: $table-row-height;
     line-height: $table-row-height;
-    border-bottom: $table-row-divider;
   }
   th {
     font-weight: $font-weight-bold;
@@ -20,6 +20,7 @@
     }
   }
   th, td {
+    border-bottom: $table-row-divider;
     position: relative;
     padding: 0 $table-row-offset;
     &.selectable {
@@ -35,7 +36,9 @@
 .row {
   transition: background-color $animation-duration $animation-curve-default;
   &:last-child {
-    border-color: transparent;
+    td {
+      border-color: transparent;
+    }
   }
   > td {
     > input {


### PR DESCRIPTION
Table borders were shown incorrectly because of the `border-collapse: separate` property (Check https://github.com/react-toolbox/react-toolbox/issues/476) .

I changed the `border-spacing` to 0 and moved the border to the cells instead of the row.

Feedback is welcome :D

Before:
![screen shot 2016-09-01 at 12 23 07](https://cloud.githubusercontent.com/assets/905225/18164192/e4297b62-703e-11e6-8b87-27418cf610b9.png)

After:

![screen shot 2016-09-01 at 12 22 28](https://cloud.githubusercontent.com/assets/905225/18164196/e9c1160c-703e-11e6-9887-4e1db3065026.png)

