### PR TITLE
fix active year style in date picker.

### DIFF
--- a/components/date_picker/_config.scss
+++ b/components/date_picker/_config.scss
@@ -21,7 +21,7 @@ $calendar-primary-contrast-color: $calendar-primary-contrast !default;
 $calendar-primary-hover-color: rgba($calendar-primary, .21) !default;
 $calendar-arrows-color: $palette-grey-600 !default;
 $calendar-arrows-font-size: 2 * $unit !default;
-$calendar-year-font-size: 2.4 !default;
+$calendar-year-font-size: 2.4 * $unit !default;
 $calendar-day-font-size: 1.3 * $unit !default;
 $calendar-day-disable-opacity: 0.25 !default;
 $calendar-row-height: 3 * $unit !default;

--- a/components/date_picker/theme.scss
+++ b/components/date_picker/theme.scss
@@ -101,6 +101,7 @@
     cursor: pointer;
     &.active {
       font-size: $calendar-year-font-size;
+      font-weight: $font-weight-semi-bold;
       color: $calendar-primary-color;
     }
   }


### PR DESCRIPTION
The active year font-size didn't have the units set (which means it
didn't work). Also to better match the material design spec the
font-weight for active years is set to semi-bold.