### PR TITLE
Fix import warning using npm types and typescript

### DIFF
--- a/components/index.d.ts
+++ b/components/index.d.ts
@@ -1,4 +1,5 @@
-export declare namespace __ReactToolbox {
+import * as React from "react";
+export declare namespace ReactToolbox {
   interface Props {
     /**
      * Set a class for the root component.
@@ -48,8 +49,8 @@ export declare namespace __ReactToolbox {
     /**
      * Set inline style for the root component.
      */
-    style?: __React.CSSProperties;
+    style?: React.CSSProperties;
   }
 }
 
-export default __ReactToolbox;
+export default ReactToolbox;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,5 @@
-export declare namespace __ReactToolbox {
+import * as React from "react";
+export declare namespace ReactToolbox {
   interface Props {
     /**
      * Set a class for the root component.
@@ -48,8 +49,8 @@ export declare namespace __ReactToolbox {
     /**
      * Set inline style for the root component.
      */
-    style?: __React.CSSProperties;
+    style?: React.CSSProperties;
   }
 }
 
-export default __ReactToolbox;
+export default ReactToolbox;


### PR DESCRIPTION
I forgot to add `components/index.d.ts` in my last pull request and the one in `lib` was replaced when you did a new build.