### PR TITLE
Pass down theme from Card title to nested Avatar

### DIFF
--- a/components/card/CardTitle.js
+++ b/components/card/CardTitle.js
@@ -13,7 +13,7 @@ const factory = (Avatar) => {
 
     return (
       <div className={classes} {...other}>
-        {typeof avatar === 'string' ? <Avatar image={avatar} /> : avatar}
+        {typeof avatar === 'string' ? <Avatar image={avatar} theme={theme} /> : avatar}
         <div>
           {title && <h5 className={theme.title}>{title}</h5>}
           {children && typeof children === 'string' && (


### PR DESCRIPTION
The current approach to theme the nested avatar was by adding a `div:first-child` selector in the .cardTitle class.
A bit less than ergonomic.