### PR TITLE
Fixing issue where closing an overlay on top of another overlay re-enables document body scrolling unnecessarily.

### DIFF
--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -33,7 +33,7 @@ class Overlay extends Component {
 
   componentWillUpdate (nextProps) {
     if (nextProps.active && !this.props.active) document.body.style.overflow = 'hidden';
-    if (!nextProps.active && this.props.active) document.body.style.overflow = '';
+    if (!nextProps.active && this.props.active && !document.querySelectorAll('[data-react-toolbox="overlay"]')[1]) document.body.style.overflow = '';
   }
 
   componentDidUpdate () {
@@ -43,7 +43,7 @@ class Overlay extends Component {
   }
 
   componentWillUnmount () {
-    document.body.style.overflow = '';
+    if (!document.querySelectorAll('[data-react-toolbox="overlay"]')[1]) document.body.style.overflow = '';
     if (this.escKeyListener) {
       document.body.removeEventListener('keydown', this.handleEscKey);
       this.escKeyListener = null;
@@ -65,7 +65,7 @@ class Overlay extends Component {
 
     return (
       <Portal>
-        <div className={_className}>
+        <div className={_className} data-react-toolbox="overlay">
           <div className={theme.backdrop} onClick={onClick} />
           {children}
         </div>

--- a/lib/overlay/Overlay.js
+++ b/lib/overlay/Overlay.js
@@ -39,7 +39,7 @@ var Overlay = function (_Component) {
   function Overlay() {
     _classCallCheck(this, Overlay);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(Overlay).apply(this, arguments));
+    return _possibleConstructorReturn(this, (Overlay.__proto__ || Object.getPrototypeOf(Overlay)).apply(this, arguments));
   }
 
   _createClass(Overlay, [{
@@ -54,7 +54,7 @@ var Overlay = function (_Component) {
     key: 'componentWillUpdate',
     value: function componentWillUpdate(nextProps) {
       if (nextProps.active && !this.props.active) document.body.style.overflow = 'hidden';
-      if (!nextProps.active && this.props.active) document.body.style.overflow = null;
+      if (!nextProps.active && this.props.active && !document.querySelectorAll('[data-react-toolbox="overlay"]')[1]) document.body.style.overflow = '';
     }
   }, {
     key: 'componentDidUpdate',
@@ -66,7 +66,7 @@ var Overlay = function (_Component) {
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
-      document.body.style.overflow = null;
+      if (!document.querySelectorAll('[data-react-toolbox="overlay"]')[1]) document.body.style.overflow = '';
       if (this.escKeyListener) {
         document.body.removeEventListener('keydown', this.handleEscKey);
         this.escKeyListener = null;
@@ -99,7 +99,7 @@ var Overlay = function (_Component) {
         null,
         _react2.default.createElement(
           'div',
-          { className: _className },
+          { className: _className, 'data-react-toolbox': 'overlay' },
           _react2.default.createElement('div', { className: theme.backdrop, onClick: onClick }),
           children
         )


### PR DESCRIPTION
I'm having an issue regarding scrolling on the document `body` when an overlay is active.



**Steps to reproduce:**

1. Have a document `body` that will scroll.

2. Open a `<Dialog />` that contains a `<DatePicker />`.

3. Open the `<DatePicker />`.

4. Close the `<DatePicker />`.



**Observed behavior:**

Despite the `<Dialog />` still being open and the document `body` still being grayed out behind it, the document `body` regains its scrolling ability.



**Expected behavior:**

The document `body` should not be scrollable until all overlays are inactive.



**Proposed solution:**

Check for other overlays before blanking out the `overflow` style attribute on the document `body`. Please let me know if this is a good approach.