### PR TITLE
Remove overlay: hidden from the body tag when an overlay is closed in IE11

### DIFF
--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -33,7 +33,7 @@ class Overlay extends Component {
 
   componentWillUpdate (nextProps) {
     if (nextProps.active && !this.props.active) document.body.style.overflow = 'hidden';
-    if (!nextProps.active && this.props.active) document.body.style.overflow = null;
+    if (!nextProps.active && this.props.active) document.body.style.overflow = "";
   }
 
   componentDidUpdate () {
@@ -43,7 +43,7 @@ class Overlay extends Component {
   }
 
   componentWillUnmount () {
-    document.body.style.overflow = null;
+    document.body.style.overflow = "";
     if (this.escKeyListener) {
       document.body.removeEventListener('keydown', this.handleEscKey);
       this.escKeyListener = null;

--- a/lib/autocomplete/Autocomplete.js
+++ b/lib/autocomplete/Autocomplete.js
@@ -64,7 +64,7 @@ var factory = function factory(Chip, Input) {
     _inherits(Autocomplete, _Component);
 
     function Autocomplete() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -74,7 +74,7 @@ var factory = function factory(Chip, Input) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Autocomplete)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Autocomplete.__proto__ || Object.getPrototypeOf(Autocomplete)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         direction: _this.props.direction,
         focus: false,
         showAllSuggestions: _this.props.showSuggestionsWhenValueIsSet,
@@ -332,11 +332,11 @@ var factory = function factory(Chip, Input) {
         var _this2 = this;
 
         if (this.props.multiple) {
-          var selectedItems = [].concat(_toConsumableArray(this.values())).map(function (_ref) {
-            var _ref2 = _slicedToArray(_ref, 2);
+          var selectedItems = [].concat(_toConsumableArray(this.values())).map(function (_ref2) {
+            var _ref3 = _slicedToArray(_ref2, 2);
 
-            var key = _ref2[0];
-            var value = _ref2[1];
+            var key = _ref3[0];
+            var value = _ref3[1];
 
             return _react2.default.createElement(
               Chip,
@@ -364,11 +364,11 @@ var factory = function factory(Chip, Input) {
 
         var theme = this.props.theme;
 
-        var suggestions = [].concat(_toConsumableArray(this.suggestions())).map(function (_ref3) {
-          var _ref4 = _slicedToArray(_ref3, 2);
+        var suggestions = [].concat(_toConsumableArray(this.suggestions())).map(function (_ref4) {
+          var _ref5 = _slicedToArray(_ref4, 2);
 
-          var key = _ref4[0];
-          var value = _ref4[1];
+          var key = _ref5[0];
+          var value = _ref5[1];
 
           var className = (0, _classnames5.default)(theme.suggestion, _defineProperty({}, theme.active, _this3.state.active === key));
           return _react2.default.createElement(

--- a/lib/button/Button.js
+++ b/lib/button/Button.js
@@ -46,7 +46,7 @@ var factory = function factory(ripple, FontIcon) {
     _inherits(Button, _Component);
 
     function Button() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -56,7 +56,7 @@ var factory = function factory(ripple, FontIcon) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Button)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleMouseUp = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Button.__proto__ || Object.getPrototypeOf(Button)).call.apply(_ref, [this].concat(args))), _this), _this.handleMouseUp = function (event) {
         _this.refs.button.blur();
         if (_this.props.onMouseUp) _this.props.onMouseUp(event);
       }, _this.handleMouseLeave = function (event) {

--- a/lib/button/IconButton.js
+++ b/lib/button/IconButton.js
@@ -46,7 +46,7 @@ var factory = function factory(ripple, FontIcon) {
     _inherits(IconButton, _Component);
 
     function IconButton() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -56,7 +56,7 @@ var factory = function factory(ripple, FontIcon) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(IconButton)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleMouseUp = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = IconButton.__proto__ || Object.getPrototypeOf(IconButton)).call.apply(_ref, [this].concat(args))), _this), _this.handleMouseUp = function (event) {
         _this.refs.button.blur();
         if (_this.props.onMouseUp) _this.props.onMouseUp(event);
       }, _this.handleMouseLeave = function (event) {

--- a/lib/checkbox/Checkbox.js
+++ b/lib/checkbox/Checkbox.js
@@ -46,7 +46,7 @@ var factory = function factory(Check) {
     _inherits(Checkbox, _Component);
 
     function Checkbox() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -56,7 +56,7 @@ var factory = function factory(Check) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Checkbox)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleToggle = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Checkbox.__proto__ || Object.getPrototypeOf(Checkbox)).call.apply(_ref, [this].concat(args))), _this), _this.handleToggle = function (event) {
         if (event.pageX !== 0 && event.pageY !== 0) _this.blur();
         if (!_this.props.disabled && _this.props.onChange) {
           _this.props.onChange(!_this.props.checked, event);

--- a/lib/date_picker/Calendar.js
+++ b/lib/date_picker/Calendar.js
@@ -43,7 +43,7 @@ var factory = function factory(IconButton) {
     _inherits(Calendar, _Component);
 
     function Calendar() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -53,7 +53,7 @@ var factory = function factory(IconButton) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Calendar)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Calendar.__proto__ || Object.getPrototypeOf(Calendar)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         viewDate: _this.props.selectedDate
       }, _this.handleDayClick = function (day) {
         _this.props.onChange(_time2.default.setDay(_this.state.viewDate, day), true);

--- a/lib/date_picker/CalendarDay.js
+++ b/lib/date_picker/CalendarDay.js
@@ -32,7 +32,7 @@ var Day = function (_Component) {
   _inherits(Day, _Component);
 
   function Day() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -42,7 +42,7 @@ var Day = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Day)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleClick = function () {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Day.__proto__ || Object.getPrototypeOf(Day)).call.apply(_ref, [this].concat(args))), _this), _this.handleClick = function () {
       if (!_this.props.disabled && _this.props.onClick) {
         _this.props.onClick(_this.props.day);
       }

--- a/lib/date_picker/CalendarMonth.js
+++ b/lib/date_picker/CalendarMonth.js
@@ -36,7 +36,7 @@ var Month = function (_Component) {
   _inherits(Month, _Component);
 
   function Month() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -46,7 +46,7 @@ var Month = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Month)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleDayClick = function (day) {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Month.__proto__ || Object.getPrototypeOf(Month)).call.apply(_ref, [this].concat(args))), _this), _this.handleDayClick = function (day) {
       if (_this.props.onDayClick) _this.props.onDayClick(day);
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }

--- a/lib/date_picker/DatePicker.js
+++ b/lib/date_picker/DatePicker.js
@@ -66,7 +66,7 @@ var factory = function factory(Input, DatePickerDialog) {
     _inherits(DatePicker, _Component);
 
     function DatePicker() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -76,7 +76,7 @@ var factory = function factory(Input, DatePickerDialog) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(DatePicker)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = DatePicker.__proto__ || Object.getPrototypeOf(DatePicker)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         active: _this.props.active
       }, _this.handleDismiss = function () {
         _this.setState({ active: false });

--- a/lib/date_picker/DatePickerDialog.js
+++ b/lib/date_picker/DatePickerDialog.js
@@ -31,7 +31,7 @@ var factory = function factory(Dialog, Calendar) {
     _inherits(CalendarDialog, _Component);
 
     function CalendarDialog() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -41,7 +41,7 @@ var factory = function factory(Dialog, Calendar) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(CalendarDialog)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = CalendarDialog.__proto__ || Object.getPrototypeOf(CalendarDialog)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         display: 'months',
         date: _this.props.value
       }, _this.handleNewDate = function (value, dayClick) {

--- a/lib/date_picker/_config.scss
+++ b/lib/date_picker/_config.scss
@@ -21,7 +21,7 @@ $calendar-primary-contrast-color: $calendar-primary-contrast !default;
 $calendar-primary-hover-color: rgba($calendar-primary, .21) !default;
 $calendar-arrows-color: $palette-grey-600 !default;
 $calendar-arrows-font-size: 2 * $unit !default;
-$calendar-year-font-size: 2.4 !default;
+$calendar-year-font-size: 2.4 * $unit !default;
 $calendar-day-font-size: 1.3 * $unit !default;
 $calendar-day-disable-opacity: 0.25 !default;
 $calendar-row-height: 3 * $unit !default;

--- a/lib/date_picker/theme.scss
+++ b/lib/date_picker/theme.scss
@@ -101,6 +101,7 @@
     cursor: pointer;
     &.active {
       font-size: $calendar-year-font-size;
+      font-weight: $font-weight-semi-bold;
       color: $calendar-primary-color;
     }
   }

--- a/lib/dropdown/Dropdown.js
+++ b/lib/dropdown/Dropdown.js
@@ -50,7 +50,7 @@ var factory = function factory(Input) {
     _inherits(Dropdown, _Component);
 
     function Dropdown() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -60,7 +60,7 @@ var factory = function factory(Input) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Dropdown)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Dropdown.__proto__ || Object.getPrototypeOf(Dropdown)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         active: false,
         up: false
       }, _this.close = function () {

--- a/lib/form/Form.js
+++ b/lib/form/Form.js
@@ -80,7 +80,7 @@ var factory = function factory(Autocomplete, Button, Checkbox, DatePicker, Dropd
     _inherits(Form, _Component);
 
     function Form() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -90,7 +90,7 @@ var factory = function factory(Autocomplete, Button, Checkbox, DatePicker, Dropd
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Form)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.onSubmit = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Form.__proto__ || Object.getPrototypeOf(Form)).call.apply(_ref, [this].concat(args))), _this), _this.onSubmit = function (event) {
         event.preventDefault();
         if (_this.props.onSubmit) _this.props.onSubmit(event);
       }, _this.onChange = function (field, value, event) {

--- a/lib/hoc/ActivableRenderer.js
+++ b/lib/hoc/ActivableRenderer.js
@@ -31,7 +31,7 @@ var ActivableRendererFactory = function ActivableRendererFactory() {
       _inherits(ActivableRenderer, _Component);
 
       function ActivableRenderer() {
-        var _Object$getPrototypeO;
+        var _ref;
 
         var _temp, _this, _ret;
 
@@ -41,7 +41,7 @@ var ActivableRendererFactory = function ActivableRendererFactory() {
           args[_key] = arguments[_key];
         }
 
-        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(ActivableRenderer)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = ActivableRenderer.__proto__ || Object.getPrototypeOf(ActivableRenderer)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
           active: _this.props.active,
           rendered: _this.props.active
         }, _temp), _possibleConstructorReturn(_this, _ret);

--- a/lib/hoc/Portal.js
+++ b/lib/hoc/Portal.js
@@ -28,7 +28,7 @@ var Portal = function (_Component) {
   function Portal() {
     _classCallCheck(this, Portal);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(Portal).apply(this, arguments));
+    return _possibleConstructorReturn(this, (Portal.__proto__ || Object.getPrototypeOf(Portal)).apply(this, arguments));
   }
 
   _createClass(Portal, [{

--- a/lib/input/Input.js
+++ b/lib/input/Input.js
@@ -44,7 +44,7 @@ var factory = function factory(FontIcon) {
     _inherits(Input, _React$Component);
 
     function Input() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -54,7 +54,7 @@ var factory = function factory(FontIcon) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Input)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleChange = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Input.__proto__ || Object.getPrototypeOf(Input)).call.apply(_ref, [this].concat(args))), _this), _this.handleChange = function (event) {
         var _this$props = _this.props;
         var onChange = _this$props.onChange;
         var multiline = _this$props.multiline;

--- a/lib/list/List.js
+++ b/lib/list/List.js
@@ -38,7 +38,7 @@ var factory = function factory(ListItem) {
     function List() {
       _classCallCheck(this, List);
 
-      return _possibleConstructorReturn(this, Object.getPrototypeOf(List).apply(this, arguments));
+      return _possibleConstructorReturn(this, (List.__proto__ || Object.getPrototypeOf(List)).apply(this, arguments));
     }
 
     _createClass(List, [{

--- a/lib/list/ListItem.js
+++ b/lib/list/ListItem.js
@@ -44,7 +44,7 @@ var factory = function factory(ripple, ListItemLayout, ListItemContent) {
     _inherits(ListItem, _Component);
 
     function ListItem() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -54,7 +54,7 @@ var factory = function factory(ripple, ListItemLayout, ListItemContent) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(ListItem)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleClick = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = ListItem.__proto__ || Object.getPrototypeOf(ListItem)).call.apply(_ref, [this].concat(args))), _this), _this.handleClick = function (event) {
         if (_this.props.onClick && !_this.props.disabled) {
           _this.props.onClick(event);
         }

--- a/lib/list/ListItemContent.js
+++ b/lib/list/ListItemContent.js
@@ -42,7 +42,7 @@ var factory = function factory(ListItemText) {
     function ListItemContent() {
       _classCallCheck(this, ListItemContent);
 
-      return _possibleConstructorReturn(this, Object.getPrototypeOf(ListItemContent).apply(this, arguments));
+      return _possibleConstructorReturn(this, (ListItemContent.__proto__ || Object.getPrototypeOf(ListItemContent)).apply(this, arguments));
     }
 
     _createClass(ListItemContent, [{

--- a/lib/menu/IconMenu.js
+++ b/lib/menu/IconMenu.js
@@ -40,7 +40,7 @@ var factory = function factory(IconButton, Menu) {
     _inherits(IconMenu, _Component);
 
     function IconMenu() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -50,7 +50,7 @@ var factory = function factory(IconButton, Menu) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(IconMenu)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = IconMenu.__proto__ || Object.getPrototypeOf(IconMenu)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         active: false
       }, _this.handleButtonClick = function (event) {
         _this.setState({ active: !_this.state.active });

--- a/lib/menu/Menu.js
+++ b/lib/menu/Menu.js
@@ -53,7 +53,7 @@ var factory = function factory(MenuItem) {
     _inherits(Menu, _Component);
 
     function Menu() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -63,7 +63,7 @@ var factory = function factory(MenuItem) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Menu)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Menu.__proto__ || Object.getPrototypeOf(Menu)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         active: _this.props.active,
         rippled: false
       }, _this.handleDocumentClick = function (event) {

--- a/lib/menu/MenuItem.js
+++ b/lib/menu/MenuItem.js
@@ -46,7 +46,7 @@ var factory = function factory(ripple) {
     _inherits(MenuItem, _Component);
 
     function MenuItem() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -56,7 +56,7 @@ var factory = function factory(ripple) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(MenuItem)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleClick = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = MenuItem.__proto__ || Object.getPrototypeOf(MenuItem)).call.apply(_ref, [this].concat(args))), _this), _this.handleClick = function (event) {
         if (_this.props.onClick && !_this.props.disabled) {
           _this.props.onClick(event, _this);
         }

--- a/lib/overlay/Overlay.js
+++ b/lib/overlay/Overlay.js
@@ -39,7 +39,7 @@ var Overlay = function (_Component) {
   function Overlay() {
     _classCallCheck(this, Overlay);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(Overlay).apply(this, arguments));
+    return _possibleConstructorReturn(this, (Overlay.__proto__ || Object.getPrototypeOf(Overlay)).apply(this, arguments));
   }
 
   _createClass(Overlay, [{
@@ -54,7 +54,7 @@ var Overlay = function (_Component) {
     key: 'componentWillUpdate',
     value: function componentWillUpdate(nextProps) {
       if (nextProps.active && !this.props.active) document.body.style.overflow = 'hidden';
-      if (!nextProps.active && this.props.active) document.body.style.overflow = null;
+      if (!nextProps.active && this.props.active) document.body.style.overflow = "";
     }
   }, {
     key: 'componentDidUpdate',
@@ -66,7 +66,7 @@ var Overlay = function (_Component) {
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
-      document.body.style.overflow = null;
+      document.body.style.overflow = "";
       if (this.escKeyListener) {
         document.body.removeEventListener('keydown', this.handleEscKey);
         this.escKeyListener = null;

--- a/lib/progress_bar/ProgressBar.js
+++ b/lib/progress_bar/ProgressBar.js
@@ -39,7 +39,7 @@ var ProgressBar = function (_Component) {
   function ProgressBar() {
     _classCallCheck(this, ProgressBar);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(ProgressBar).apply(this, arguments));
+    return _possibleConstructorReturn(this, (ProgressBar.__proto__ || Object.getPrototypeOf(ProgressBar)).apply(this, arguments));
   }
 
   _createClass(ProgressBar, [{

--- a/lib/radio/RadioButton.js
+++ b/lib/radio/RadioButton.js
@@ -44,7 +44,7 @@ var factory = function factory(Radio) {
     _inherits(RadioButton, _Component);
 
     function RadioButton() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -54,7 +54,7 @@ var factory = function factory(Radio) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(RadioButton)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleClick = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = RadioButton.__proto__ || Object.getPrototypeOf(RadioButton)).call.apply(_ref, [this].concat(args))), _this), _this.handleClick = function (event) {
         var _this$props = _this.props;
         var checked = _this$props.checked;
         var disabled = _this$props.disabled;

--- a/lib/radio/RadioGroup.js
+++ b/lib/radio/RadioGroup.js
@@ -34,7 +34,7 @@ var factory = function factory(RadioButton) {
     _inherits(RadioGroup, _Component);
 
     function RadioGroup() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -44,7 +44,7 @@ var factory = function factory(RadioButton) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(RadioGroup)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleChange = function (value) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = RadioGroup.__proto__ || Object.getPrototypeOf(RadioGroup)).call.apply(_ref, [this].concat(args))), _this), _this.handleChange = function (value) {
         if (_this.props.onChange) _this.props.onChange(value);
       }, _temp), _possibleConstructorReturn(_this, _ret);
     }

--- a/lib/ripple/Ripple.js
+++ b/lib/ripple/Ripple.js
@@ -78,7 +78,7 @@ var rippleFactory = function rippleFactory() {
       _inherits(RippledComponent, _Component);
 
       function RippledComponent() {
-        var _Object$getPrototypeO;
+        var _ref;
 
         var _temp, _this, _ret;
 
@@ -88,7 +88,7 @@ var rippleFactory = function rippleFactory() {
           args[_key] = arguments[_key];
         }
 
-        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(RippledComponent)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = RippledComponent.__proto__ || Object.getPrototypeOf(RippledComponent)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
           ripples: {}
         }, _this.handleMouseDown = function (event) {
           if (_this.props.onMouseDown) _this.props.onMouseDown(event);
@@ -304,14 +304,14 @@ var rippleFactory = function rippleFactory() {
         }
       }, {
         key: 'renderRipple',
-        value: function renderRipple(key, className, _ref) {
+        value: function renderRipple(key, className, _ref2) {
           var _classnames;
 
-          var active = _ref.active;
-          var left = _ref.left;
-          var restarting = _ref.restarting;
-          var top = _ref.top;
-          var width = _ref.width;
+          var active = _ref2.active;
+          var left = _ref2.left;
+          var restarting = _ref2.restarting;
+          var top = _ref2.top;
+          var width = _ref2.width;
 
           var scale = restarting ? 0 : 1;
           var transform = 'translate3d(' + (-width / 2 + left) + 'px, ' + (-width / 2 + top) + 'px, 0) scale(' + scale + ')';

--- a/lib/slider/Slider.js
+++ b/lib/slider/Slider.js
@@ -58,7 +58,7 @@ var factory = function factory(ProgressBar, Input) {
     _inherits(Slider, _Component);
 
     function Slider() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -68,7 +68,7 @@ var factory = function factory(ProgressBar, Input) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Slider)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Slider.__proto__ || Object.getPrototypeOf(Slider)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         inputFocused: false,
         inputValue: null,
         sliderLength: 0,

--- a/lib/snackbar/Snackbar.js
+++ b/lib/snackbar/Snackbar.js
@@ -52,7 +52,7 @@ var factory = function factory(Overlay, Button) {
     function Snackbar() {
       _classCallCheck(this, Snackbar);
 
-      return _possibleConstructorReturn(this, Object.getPrototypeOf(Snackbar).apply(this, arguments));
+      return _possibleConstructorReturn(this, (Snackbar.__proto__ || Object.getPrototypeOf(Snackbar)).apply(this, arguments));
     }
 
     _createClass(Snackbar, [{

--- a/lib/switch/Switch.js
+++ b/lib/switch/Switch.js
@@ -44,7 +44,7 @@ var factory = function factory(Thumb) {
     _inherits(Switch, _Component);
 
     function Switch() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -54,7 +54,7 @@ var factory = function factory(Thumb) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Switch)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleToggle = function (event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Switch.__proto__ || Object.getPrototypeOf(Switch)).call.apply(_ref, [this].concat(args))), _this), _this.handleToggle = function (event) {
         if (event.pageX !== 0 && event.pageY !== 0) _this.blur();
         if (!_this.props.disabled && _this.props.onChange) {
           _this.props.onChange(!_this.props.checked, event);

--- a/lib/table/Table.js
+++ b/lib/table/Table.js
@@ -46,7 +46,7 @@ var factory = function factory(TableHead, TableRow) {
     _inherits(Table, _Component);
 
     function Table() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -56,7 +56,7 @@ var factory = function factory(TableHead, TableRow) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Table)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleFullSelect = function () {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Table.__proto__ || Object.getPrototypeOf(Table)).call.apply(_ref, [this].concat(args))), _this), _this.handleFullSelect = function () {
         if (_this.props.onSelect) {
           var _this$props = _this.props;
           var source = _this$props.source;

--- a/lib/table/TableRow.js
+++ b/lib/table/TableRow.js
@@ -33,7 +33,7 @@ var factory = function factory(Checkbox) {
     _inherits(TableRow, _Component);
 
     function TableRow() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -43,7 +43,7 @@ var factory = function factory(Checkbox) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(TableRow)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleInputChange = function (index, key, type, event) {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TableRow.__proto__ || Object.getPrototypeOf(TableRow)).call.apply(_ref, [this].concat(args))), _this), _this.handleInputChange = function (index, key, type, event) {
         var value = type === 'checkbox' ? event.target.checked : event.target.value;
         var onChange = _this.props.model[key].onChange || _this.props.onChange;
         onChange(index, key, value);

--- a/lib/tabs/Tab.js
+++ b/lib/tabs/Tab.js
@@ -39,7 +39,7 @@ var Tab = function (_Component) {
   _inherits(Tab, _Component);
 
   function Tab() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -49,7 +49,7 @@ var Tab = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Tab)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleClick = function (event) {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Tab.__proto__ || Object.getPrototypeOf(Tab)).call.apply(_ref, [this].concat(args))), _this), _this.handleClick = function (event) {
       if (!_this.props.disabled && _this.props.onClick) {
         _this.props.onClick(event);
       }

--- a/lib/tabs/TabContent.js
+++ b/lib/tabs/TabContent.js
@@ -35,7 +35,7 @@ var TabContent = function (_Component) {
   function TabContent() {
     _classCallCheck(this, TabContent);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(TabContent).apply(this, arguments));
+    return _possibleConstructorReturn(this, (TabContent.__proto__ || Object.getPrototypeOf(TabContent)).apply(this, arguments));
   }
 
   _createClass(TabContent, [{

--- a/lib/tabs/Tabs.js
+++ b/lib/tabs/Tabs.js
@@ -42,7 +42,7 @@ var factory = function factory(Tab, TabContent) {
     _inherits(Tabs, _Component);
 
     function Tabs() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -52,7 +52,7 @@ var factory = function factory(Tab, TabContent) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Tabs)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Tabs.__proto__ || Object.getPrototypeOf(Tabs)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         pointer: {}
       }, _this.handleHeaderClick = function (event) {
         var idx = parseInt(event.currentTarget.id);

--- a/lib/tabs/__tests__/index.spec.js
+++ b/lib/tabs/__tests__/index.spec.js
@@ -63,7 +63,7 @@ describe('Tabs', function () {
     function Composition() {
       _classCallCheck(this, Composition);
 
-      var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Composition).call(this));
+      var _this = _possibleConstructorReturn(this, (Composition.__proto__ || Object.getPrototypeOf(Composition)).call(this));
 
       _this.state = { index: 0 };
       return _this;

--- a/lib/time_picker/Clock.js
+++ b/lib/time_picker/Clock.js
@@ -40,7 +40,7 @@ var Clock = function (_Component) {
   _inherits(Clock, _Component);
 
   function Clock() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -50,7 +50,7 @@ var Clock = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Clock)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Clock.__proto__ || Object.getPrototypeOf(Clock)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       center: { x: null, y: null },
       radius: 0
     }, _this.handleHourChange = function (hours) {

--- a/lib/time_picker/ClockFace.js
+++ b/lib/time_picker/ClockFace.js
@@ -28,7 +28,7 @@ var Face = function (_Component) {
   _inherits(Face, _Component);
 
   function Face() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -38,7 +38,7 @@ var Face = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Face)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.renderNumber = function (number, idx) {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Face.__proto__ || Object.getPrototypeOf(Face)).call.apply(_ref, [this].concat(args))), _this), _this.renderNumber = function (number, idx) {
       var _this$props = _this.props;
       var active = _this$props.active;
       var radius = _this$props.radius;

--- a/lib/time_picker/ClockHand.js
+++ b/lib/time_picker/ClockHand.js
@@ -34,7 +34,7 @@ var Hand = function (_Component) {
   _inherits(Hand, _Component);
 
   function Hand() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -44,7 +44,7 @@ var Hand = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Hand)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Hand.__proto__ || Object.getPrototypeOf(Hand)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       knobWidth: 0
     }, _this.handleMouseMove = function (event) {
       _this.move(_events2.default.getMousePosition(event));

--- a/lib/time_picker/ClockHours.js
+++ b/lib/time_picker/ClockHours.js
@@ -41,7 +41,7 @@ var Hours = function (_Component) {
   _inherits(Hours, _Component);
 
   function Hours() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -51,7 +51,7 @@ var Hours = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Hours)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Hours.__proto__ || Object.getPrototypeOf(Hours)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
       inner: _this.props.format === '24hr' && _this.props.selected > 0 && _this.props.selected <= 12
     }, _this.handleHandMove = function (degrees, radius) {
       var currentInner = radius < _this.props.radius - _this.props.spacing * innerSpacing;

--- a/lib/time_picker/ClockMinutes.js
+++ b/lib/time_picker/ClockMinutes.js
@@ -37,7 +37,7 @@ var Minutes = function (_Component) {
   _inherits(Minutes, _Component);
 
   function Minutes() {
-    var _Object$getPrototypeO;
+    var _ref;
 
     var _temp, _this, _ret;
 
@@ -47,7 +47,7 @@ var Minutes = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Minutes)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.handleHandMove = function (degrees) {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Minutes.__proto__ || Object.getPrototypeOf(Minutes)).call.apply(_ref, [this].concat(args))), _this), _this.handleHandMove = function (degrees) {
       _this.props.onChange(degrees / step);
     }, _this.handleMouseDown = function (event) {
       _this.refs.hand.mouseStart(event);

--- a/lib/time_picker/TimePicker.js
+++ b/lib/time_picker/TimePicker.js
@@ -58,7 +58,7 @@ var factory = function factory(TimePickerDialog, Input) {
     _inherits(TimePicker, _Component);
 
     function TimePicker() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -68,7 +68,7 @@ var factory = function factory(TimePickerDialog, Input) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(TimePicker)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TimePicker.__proto__ || Object.getPrototypeOf(TimePicker)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         active: _this.props.active
       }, _this.handleDismiss = function () {
         _this.setState({ active: false });

--- a/lib/time_picker/TimePickerDialog.js
+++ b/lib/time_picker/TimePickerDialog.js
@@ -35,7 +35,7 @@ var factory = function factory(Dialog) {
     _inherits(TimePickerDialog, _Component);
 
     function TimePickerDialog() {
-      var _Object$getPrototypeO;
+      var _ref;
 
       var _temp, _this, _ret;
 
@@ -45,7 +45,7 @@ var factory = function factory(Dialog) {
         args[_key] = arguments[_key];
       }
 
-      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(TimePickerDialog)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+      return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TimePickerDialog.__proto__ || Object.getPrototypeOf(TimePickerDialog)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
         display: 'hours',
         displayTime: _this.props.value
       }, _this.handleClockChange = function (value) {

--- a/lib/tooltip/Tooltip.js
+++ b/lib/tooltip/Tooltip.js
@@ -78,7 +78,7 @@ var tooltipFactory = function tooltipFactory() {
       _inherits(TooltippedComponent, _Component);
 
       function TooltippedComponent() {
-        var _Object$getPrototypeO;
+        var _ref;
 
         var _temp, _this, _ret;
 
@@ -88,7 +88,7 @@ var tooltipFactory = function tooltipFactory() {
           args[_key] = arguments[_key];
         }
 
-        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(TooltippedComponent)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.state = {
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TooltippedComponent.__proto__ || Object.getPrototypeOf(TooltippedComponent)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
           active: false,
           position: _this.props.tooltipPosition,
           visible: false
@@ -118,12 +118,12 @@ var tooltipFactory = function tooltipFactory() {
         }
       }, {
         key: 'activate',
-        value: function activate(_ref) {
+        value: function activate(_ref2) {
           var _this2 = this;
 
-          var top = _ref.top;
-          var left = _ref.left;
-          var position = _ref.position;
+          var top = _ref2.top;
+          var left = _ref2.left;
+          var position = _ref2.position;
 
           if (this.timeout) clearTimeout(this.timeout);
           this.setState({ visible: true, position: position });


### PR DESCRIPTION
In IE11 setting

```document.body.style.overflow = null;```

does not work. But

``` document.body.style.overflow = "";```

does.

Using the empty string works for me today in Chrome Canary, Firefox Dev, iOS Safari, OSX Safari 9.1.1.