### PR TITLE
Fixes scroll after overlay closing in IE11

### DIFF
--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -33,7 +33,7 @@ class Overlay extends Component {
 
   componentWillUpdate (nextProps) {
     if (nextProps.active && !this.props.active) document.body.style.overflow = 'hidden';
-    if (!nextProps.active && this.props.active) document.body.style.overflow = null;
+    if (!nextProps.active && this.props.active) document.body.style.overflow = "";
   }
 
   componentDidUpdate () {
@@ -43,7 +43,7 @@ class Overlay extends Component {
   }
 
   componentWillUnmount () {
-    document.body.style.overflow = null;
+    document.body.style.overflow = "";
     if (this.escKeyListener) {
       document.body.removeEventListener('keydown', this.handleEscKey);
       this.escKeyListener = null;

--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -33,7 +33,7 @@ class Overlay extends Component {
 
   componentWillUpdate (nextProps) {
     if (nextProps.active && !this.props.active) document.body.style.overflow = 'hidden';
-    if (!nextProps.active && this.props.active) document.body.style.overflow = "";
+    if (!nextProps.active && this.props.active) document.body.style.overflow = '';
   }
 
   componentDidUpdate () {
@@ -43,7 +43,7 @@ class Overlay extends Component {
   }
 
   componentWillUnmount () {
-    document.body.style.overflow = "";
+    document.body.style.overflow = '';
     if (this.escKeyListener) {
       document.body.removeEventListener('keydown', this.handleEscKey);
       this.escKeyListener = null;


### PR DESCRIPTION
In IE11 setting

```document.body.style.overflow = null;```

does not work. But

``` document.body.style.overflow = '';```

does.

Using the empty string works for me today in Chrome Canary, Firefox Dev, iOS Safari, OSX Safari 9.1.1.