### PR TITLE
Fix multiple default exports in Datepicker

### DIFF
--- a/components/date_picker/index.js
+++ b/components/date_picker/index.js
@@ -1,5 +1,3 @@
-export default from './DatePicker';
-
 import { themr } from 'react-css-themr';
 import { DATE_PICKER, DIALOG } from '../identifiers.js';
 import { datePickerFactory } from './DatePicker.js';


### PR DESCRIPTION
Found the build breaking due to multiple default exports in datepicker component, while I was about to make a change in App Drawer. This is a fix to the issue :

Error Logs from travis :

```
SyntaxError: components/date_picker/index.js: Only one default export allowed per module. (19:0)
  17 | 
  18 | const ThemedDatePicker = themr(DATE_PICKER, theme)(DatePicker);
> 19 | export default ThemedDatePicker;
     | ^
  20 | export { ThemedDatePicker as DatePicker };
  21 | 
  22 | const ThemedDatePickerDialog = themr(DIALOG, theme)(DatePickerDialog);


```