### PR TITLE
Updated Sass/ Typescript build commands to add Windows support and added support for clicking on row in table

### DIFF
--- a/components/date_picker/index.js
+++ b/components/date_picker/index.js
@@ -1,5 +1,3 @@
-export default from './DatePicker';
-
 import { themr } from 'react-css-themr';
 import { DATE_PICKER, DIALOG } from '../identifiers.js';
 import { datePickerFactory } from './DatePicker.js';

--- a/components/table/Table.js
+++ b/components/table/Table.js
@@ -61,6 +61,10 @@ const factory = (TableHead, TableRow) => {
       }
     };
 
+    handleRowClick = (index, event) => {
+      this.props.onRowClick ? this.props.onRowClick(index, event) : "";
+    }
+
     renderHead () {
       if (this.props.heading) {
         const {model, selected, source, selectable, multiSelectable} = this.props;
@@ -90,6 +94,7 @@ const factory = (TableHead, TableRow) => {
               model={model}
               onChange={onChange ? this.handleRowChange.bind(this) : undefined}
               onSelect={this.handleRowSelect.bind(this, index)}
+              onRowClick={this.handleRowClick.bind(this, index)}
               selectable={selectable}
               selected={selected.indexOf(index) !== -1}
               theme={theme}

--- a/components/table/TableRow.js
+++ b/components/table/TableRow.js
@@ -8,7 +8,6 @@ const factory = (Checkbox) => {
       data: PropTypes.object,
       index: PropTypes.number,
       model: PropTypes.object,
-      onChange: PropTypes.func,
       onSelect: PropTypes.func,
       selectable: PropTypes.bool,
       selected: PropTypes.bool,
@@ -38,7 +37,7 @@ const factory = (Checkbox) => {
 
     renderCells () {
       return Object.keys(this.props.model).map((key) => {
-        return <td key={key}>{this.renderCell(key)}</td>;
+        return <td key={key} onClick={this.props.onRowClick}>{this.renderCell(key)}</td>
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "prebuild": "npm run clean",
     "prepublish": "npm run build",
     "release": "bumped release",
-    "sass": "cpx './components/**/*.scss' ./lib",
+    "sass": "cpx \"./components/**/*.scss\" ./lib",
     "start": "cross-env NODE_ENV=development UV_THREADPOOL_SIZE=100 node ./server",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test karma start --no-single-run",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "start": "cross-env NODE_ENV=development UV_THREADPOOL_SIZE=100 node ./server",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test karma start --no-single-run",
-    "tsd": "cpx './components/**/*.d.ts' ./lib"
+    "tsd": "cpx \"./components/**/*.d.ts\" ./lib"
   },
   "license": "MIT",
   "peerDependencies": {


### PR DESCRIPTION
- Added support for sass and typescript copying of files for Windows users, cpx requires double quotes and not single quotes

- Added the ability to click on a row via passing down a onClick handler

- Removed a duplicate default export from the datepicker file caught in the linting process