### PR TITLE
Use 4p shadow in AppBar as spec indicates

### DIFF
--- a/components/app_bar/theme.css
+++ b/components/app_bar/theme.css
@@ -12,7 +12,7 @@
   padding: 0 var(--appbar-h-padding);
 
   &:not(.flat) {
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
+    box-shadow: var(--shadow-4p);
     z-index: var(--z-index-high);
   }
 


### PR DESCRIPTION
As issue #815 says, in the [material design spec](https://material.google.com/material-design/elevation-shadows.html#elevation-shadows-shadows) the shadow of Appbar is 4dp.