### PR TITLE
Fixed Tooltip TypeError when quickly hovering between multiple tooltips

### DIFF
--- a/components/utils/events.js
+++ b/components/utils/events.js
@@ -63,7 +63,7 @@ const TRANSITIONS = {
 
 function transitionEventNamesFor (element) {
   for (const transition in TRANSITIONS) {
-    if (element.style[transition] !== undefined) {
+    if (element && element.style[transition] !== undefined) {
       return TRANSITIONS[transition];
     }
   }


### PR DESCRIPTION
This PR is for issue https://github.com/react-toolbox/react-toolbox/issues/780 "Tooltip TypeError when quickly hovering between multiple tooltips"

When you move cursor between elements too fast, the `transitionEventNamesFor()` function could be called with an element that does not exist anymore so  `element.style[transition]` throw the error.