### PR TITLE
Added ::after pseudo to CardMedia to fix an issue in FireFox

### DIFF
--- a/components/card/theme.scss
+++ b/components/card/theme.scss
@@ -27,7 +27,6 @@
   background-size: cover;
   &.wide, &.square {
     width: 100%;
-    height: 0;
     .content {
       position: absolute;
       height: 100%;
@@ -36,10 +35,15 @@
       max-width: 100%;
     }
   }
-  &.wide {
+  &::after {
+    display: block;
+    height: 0;
+    content: "";
+  }
+  &.wide::after {
     padding-top: 56.25%;
   }
-  &.square {
+  &.square::after {
     padding-top: 100%;
   }
   .content {


### PR DESCRIPTION
Added ::after pseudo to CardMedia to fix the issue with not showing images in FF
https://github.com/react-toolbox/react-toolbox/issues/253

FireFox:
<img width="1465" alt="screen shot 2016-10-09 at 21 17 12" src="https://cloud.githubusercontent.com/assets/746383/19222664/c2339556-8e66-11e6-8efb-00f8ec2180ce.png">

Chrome:
![screen shot 2016-10-09 at 21 28 59](https://cloud.githubusercontent.com/assets/746383/19222706/74cbedbc-8e67-11e6-9755-7a0892dd5f80.png)
