### PR TITLE
fixes old sass var in css config

### DIFF
--- a/lib/list/config.css
+++ b/lib/list/config.css
@@ -8,7 +8,7 @@
   --list-divider-height: calc(0.1 * var(--unit));
   --list-item-min-height: calc(4.8 * var(--unit));
   --list-item-min-height-legend: calc(7.2 * var(--unit));
-  --list-item-hover-color: $palette-grey-200;
+  --list-item-hover-color: var(--palette-grey-200);
   --list-item-legend-margin-top: calc(0.3 * var(--unit));
   --list-item-icon-font-size: calc(2.4 * var(--unit));
   --list-item-icon-size: calc(1.8 * var(--unit));


### PR DESCRIPTION
There was an old sass variable in the config.css file that breaks for css-only setups.