### PR TITLE
Fix Overlay Memory Leak

### DIFF
--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -26,7 +26,7 @@ class Overlay extends Component {
 
   componentDidMount () {
     if (this.props.active) {
-      this.escKeyListener = document.body.addEventListener('keydown', this.handleEscKey.bind(this));
+      document.body.addEventListener('keydown', this.handleEscKey);
       document.body.style.overflow = 'hidden';
     }
   }
@@ -37,20 +37,17 @@ class Overlay extends Component {
   }
 
   componentDidUpdate () {
-    if (this.props.active && !this.escKeyListener) {
-      this.escKeyListener = document.body.addEventListener('keydown', this.handleEscKey.bind(this));
+    if (this.props.active) {
+      document.body.addEventListener('keydown', this.handleEscKey);
     }
   }
 
   componentWillUnmount () {
     if (!document.querySelectorAll('[data-react-toolbox="overlay"]')[1]) document.body.style.overflow = '';
-    if (this.escKeyListener) {
-      document.body.removeEventListener('keydown', this.handleEscKey);
-      this.escKeyListener = null;
-    }
+    document.body.removeEventListener('keydown', this.handleEscKey);
   }
 
-  handleEscKey (e) {
+  handleEscKey = (e) => {
     if (this.props.active && this.props.onEscKeyDown && e.which === 27) {
       this.props.onEscKeyDown(e);
     }

--- a/lib/overlay/Overlay.js
+++ b/lib/overlay/Overlay.js
@@ -37,16 +37,28 @@ var Overlay = function (_Component) {
   _inherits(Overlay, _Component);
 
   function Overlay() {
+    var _ref;
+
+    var _temp, _this, _ret;
+
     _classCallCheck(this, Overlay);
 
-    return _possibleConstructorReturn(this, (Overlay.__proto__ || Object.getPrototypeOf(Overlay)).apply(this, arguments));
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Overlay.__proto__ || Object.getPrototypeOf(Overlay)).call.apply(_ref, [this].concat(args))), _this), _this.handleEscKey = function (e) {
+      if (_this.props.active && _this.props.onEscKeyDown && e.which === 27) {
+        _this.props.onEscKeyDown(e);
+      }
+    }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 
   _createClass(Overlay, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
       if (this.props.active) {
-        this.escKeyListener = document.body.addEventListener('keydown', this.handleEscKey.bind(this));
+        document.body.addEventListener('keydown', this.handleEscKey);
         document.body.style.overflow = 'hidden';
       }
     }
@@ -59,25 +71,15 @@ var Overlay = function (_Component) {
   }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate() {
-      if (this.props.active && !this.escKeyListener) {
-        this.escKeyListener = document.body.addEventListener('keydown', this.handleEscKey.bind(this));
+      if (this.props.active) {
+        document.body.addEventListener('keydown', this.handleEscKey);
       }
     }
   }, {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       if (!document.querySelectorAll('[data-react-toolbox="overlay"]')[1]) document.body.style.overflow = '';
-      if (this.escKeyListener) {
-        document.body.removeEventListener('keydown', this.handleEscKey);
-        this.escKeyListener = null;
-      }
-    }
-  }, {
-    key: 'handleEscKey',
-    value: function handleEscKey(e) {
-      if (this.props.active && this.props.onEscKeyDown && e.which === 27) {
-        this.props.onEscKeyDown(e);
-      }
+      document.body.removeEventListener('keydown', this.handleEscKey);
     }
   }, {
     key: 'render',


### PR DESCRIPTION
The [Overlay Component](https://github.com/react-toolbox/react-toolbox/blob/dev/components/overlay/Overlay.js) doesn't remove the `keydown` listener when it is unmounted.
This is because `this.handleEscKey.bind(this) !== this.handleEscKey` [(code)](https://github.com/react-toolbox/react-toolbox/blob/dev/components/overlay/Overlay.js#L29)

This prevents garbage collection of the component as well fires the `handleEscKey` listener even when the component has been unmounted.

@javivelasco Since this is a critical bug I would love to see this fix in Version 1 as well.