### PR TITLE
Remove normalize.css from commons.css

### DIFF
--- a/components/commons.css
+++ b/components/commons.css
@@ -1,4 +1,3 @@
-@import 'normalize.css';
 @import './colors.css';
 @import './variables.css';
 

--- a/components/list/config.css
+++ b/components/list/config.css
@@ -8,7 +8,7 @@
   --list-divider-height: calc(0.1 * var(--unit));
   --list-item-min-height: calc(4.8 * var(--unit));
   --list-item-min-height-legend: calc(7.2 * var(--unit));
-  --list-item-hover-color: $palette-grey-200;
+  --list-item-hover-color: var(--palette-grey-200);
   --list-item-legend-margin-top: calc(0.3 * var(--unit));
   --list-item-icon-font-size: calc(2.4 * var(--unit));
   --list-item-icon-size: calc(1.8 * var(--unit));

--- a/lib/commons.css
+++ b/lib/commons.css
@@ -1,4 +1,3 @@
-@import 'normalize.css';
 @import './colors.css';
 @import './variables.css';
 

--- a/lib/list/config.css
+++ b/lib/list/config.css
@@ -8,7 +8,7 @@
   --list-divider-height: calc(0.1 * var(--unit));
   --list-item-min-height: calc(4.8 * var(--unit));
   --list-item-min-height-legend: calc(7.2 * var(--unit));
-  --list-item-hover-color: $palette-grey-200;
+  --list-item-hover-color: var(--palette-grey-200);
   --list-item-legend-margin-top: calc(0.3 * var(--unit));
   --list-item-icon-font-size: calc(2.4 * var(--unit));
   --list-item-icon-size: calc(1.8 * var(--unit));

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "classnames": "~2.2.5",
     "core-js": "~2.4.0",
-    "normalize.css": "~5.0.0",
     "react-css-themr": "~1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This splits out global styles defined in commons.css into global.css.
This gives users the option to include either commons.css
(just as before) or global.css (which is everything but normalize.css).

Users should have the option to handle importing external dependencies
like normalize.css separately from the rest of the toolbox's common styles.

This also includes a commit to fixup da0c470.