### PR TITLE
add support for FontAwesome

### DIFF
--- a/components/font_icon/FontAwesomeIcon.js
+++ b/components/font_icon/FontAwesomeIcon.js
@@ -1,0 +1,21 @@
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
+
+const FontAwesomeIcon = ({name, modifiers, className, ...rest}) => {
+  const modifierClasses = modifiers ? modifiers.split(',').map((m) => (`fa-${m}`)) : null;
+  return (
+    <span
+      className={classnames(className, 'fa', `fa-${name}`, modifierClasses)}
+      {...rest}
+    />
+  );
+};
+
+
+FontAwesomeIcon.propTypes = {
+  className: PropTypes.className,
+  modifiers: PropTypes.string,
+  name: PropTypes.string
+};
+
+export default FontAwesomeIcon;

--- a/components/font_icon/FontIcon.js
+++ b/components/font_icon/FontIcon.js
@@ -1,16 +1,27 @@
 import React, { PropTypes } from 'react';
-import classnames from 'classnames';
+import MaterialIcon from './MaterialIcon';
+import FontAwesomeIcon from './FontAwesomeIcon';
 
-const FontIcon = ({ children, className, value, ...other}) => (
-  <span
-    data-react-toolbox='font-icon'
-    className={classnames({'material-icons': typeof value === 'string' || typeof children === 'string'}, className)}
-    {...other}
-  >
-    {value}
-    {children}
-  </span>
-);
+const IconSpecRegExp = /(?:([^:]+):|)([^:]+)(?::(.*)|)/;
+
+const FontIcon = ({ value, ...rest}) => {
+  if (typeof value === 'string') {
+      const valueParts = value.match(IconSpecRegExp),
+            provider = valueParts[1],
+            name = valueParts[2],
+            modifiers = valueParts[3];
+
+      switch (provider) {
+        case 'fa':
+          return <FontAwesomeIcon name={name} modifiers={modifiers} {...rest} />;
+        case 'material':
+        default:
+          return <MaterialIcon value={name} {...rest} />;
+      }
+  } else {
+    return <MaterialIcon value={value} {...rest} />;
+  }
+};
 
 FontIcon.propTypes = {
   children: PropTypes.any,

--- a/components/font_icon/MaterialIcon.js
+++ b/components/font_icon/MaterialIcon.js
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
+
+const MaterialIcon = ({ children, className, value, ...other}) => (
+  <span
+    data-react-toolbox='font-icon'
+    className={classnames({'material-icons': typeof value === 'string' || typeof children === 'string'}, className)}
+    {...other}
+  >
+    {value}
+    {children}
+  </span>
+);
+
+MaterialIcon.propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ])
+};
+
+export default MaterialIcon;

--- a/spec/components/avatar.js
+++ b/spec/components/avatar.js
@@ -13,6 +13,7 @@ const AvatarTest = () => (
     <Avatar image="http://www.thewrap.com/wp-content/uploads/2015/08/margot-robbie-harley-quinn_main.jpg" cover />
     <Avatar title="Javier"/>
     <Avatar style={{backgroundColor: 'yellowgreen'}}><GithubIcon /></Avatar>
+    <Avatar style={{backgroundColor: 'deepskyblue'}} icon="fa:user" />
   </section>
 );
 

--- a/spec/components/button.js
+++ b/spec/components/button.js
@@ -40,6 +40,10 @@ const ButtonTest = () => (
     <BrowseButton icon='folder_open' label='BROWSE' raised primary />
     &nbsp;
     <BrowseButton label='BROWSE' raised />
+
+    <h5>With font awesome</h5>
+    <IconButton icon='fa:bars' />
+    <Button icon='fa:bars' label="Menu" />
 </section>
 );
 

--- a/spec/components/font_icon.js
+++ b/spec/components/font_icon.js
@@ -11,6 +11,17 @@ const FontIconTest = () => (
     <FontIcon value="explore"/>
     <FontIcon value="zoom_in"/>
     <FontIcon>input</FontIcon>
+
+    <h5>Using FontAwesome</h5>
+    Basic: <FontIcon value="fa:leaf"/>
+    <br />
+    With modifiers: <FontIcon value="fa:cog:spin"/> <FontIcon value="fa:cog:border"/>
+
+    <h5>font awesome inline with text</h5>
+    <div>
+      <FontIcon value="fa:search-plus:fw"/>
+      Some text
+    </div>
   </section>
 );
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -13,6 +13,7 @@
     <meta name="format-detection" content="telephone=no">
     <meta name="HandheldFriendly" content="True">
     <meta http-equiv="cleartype" content="on">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
     <link rel="stylesheet" href="/build/spec.css">


### PR DESCRIPTION
react-toolbox rocks!

I was missing font-awesome, which providers a lot of icons missing from the material icon pack.

This is an attempt at making react-toolbox support font-awesome using a simple icon name prefix.
It's early work, so there's probably a lot of things that can be improved

WDYT?
