### PR TITLE
Fixed issue with rendering calendar incorrectly when first day of a m…

### DIFF
--- a/components/date_picker/CalendarDay.js
+++ b/components/date_picker/CalendarDay.js
@@ -20,8 +20,9 @@ class Day extends Component {
   dayStyle () {
     if (this.props.day === 1) {
       const e = (this.props.sundayFirstDayOfWeek) ? 0 : 1;
+      const firstDay = time.getFirstWeekDay(this.props.viewDate) - e;
       return {
-        marginLeft: `${(time.getFirstWeekDay(this.props.viewDate) - e) * 100 / 7}%`
+        marginLeft: `${ (firstDay >= 0 ? firstDay : 6) * 100 / 7 }%`
       };
     }
   }


### PR DESCRIPTION
This PR is a fix for https://github.com/react-toolbox/react-toolbox/issues/870 - May 1st missing

The problem is in calculating correct position for the first day of the first month's week.
If it's on Sunday and Sunday is the first day of the week, current calculation is correct, but in case Sunday is the last day of the week, it sets -1 as the position and we don't see this day.  

<img width="345" alt="screen shot 2016-10-15 at 14 00 41" src="https://cloud.githubusercontent.com/assets/746383/19409714/c8fe8f00-92e2-11e6-94bf-b52194a5266f.png">

<img width="352" alt="screen shot 2016-10-15 at 14 00 52" src="https://cloud.githubusercontent.com/assets/746383/19409713/c8fe49e6-92e2-11e6-99f2-c84a82a4e80a.png">

