### PR TITLE
Fix Switch white-space bug

### DIFF
--- a/components/switch/theme.scss
+++ b/components/switch/theme.scss
@@ -6,7 +6,7 @@
 .field {
   position: relative;
   display: block;
-  height: $switch-total-height;
+  height: auto;
   margin-bottom: $switch-field-margin-bottom;
   white-space: nowrap;
   vertical-align: middle;
@@ -18,7 +18,7 @@
   font-size: $switch-font-size;
   line-height: $switch-total-height;
   color: $switch-text-color;
-  white-space: nowrap;
+  white-space: normal;
   vertical-align: top;
 }
 

--- a/lib/switch/theme.scss
+++ b/lib/switch/theme.scss
@@ -6,7 +6,7 @@
 .field {
   position: relative;
   display: block;
-  height: $switch-total-height;
+  height: auto;
   margin-bottom: $switch-field-margin-bottom;
   white-space: nowrap;
   vertical-align: middle;
@@ -18,7 +18,7 @@
   font-size: $switch-font-size;
   line-height: $switch-total-height;
   color: $switch-text-color;
-  white-space: nowrap;
+  white-space: normal;
   vertical-align: top;
 }
 


### PR DESCRIPTION
### Bug

Text that doesn't fit in the viewport is currently hidden.

### Screenshot

![bildschirmfoto 2016-10-22 um 14 44 15](https://cloud.githubusercontent.com/assets/1265681/19619414/e1e69452-9866-11e6-8bf0-46b634cc9edd.png)
