### PR TITLE
Pass currently active suggestion to onBlur handler

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -93,7 +93,7 @@ const factory = (Chip, Input) => {
 
    handleQueryBlur = (event) => {
      if (this.state.focus) this.setState({focus: false});
-     if (this.props.onBlur) this.props.onBlur(event);
+     if (this.props.onBlur) this.props.onBlur(event, this.state.active);
    };
 
    handleQueryChange = (value) => {

--- a/lib/autocomplete/Autocomplete.js
+++ b/lib/autocomplete/Autocomplete.js
@@ -88,7 +88,7 @@ var factory = function factory(Chip, Input) {
         });
       }, _this.handleQueryBlur = function (event) {
         if (_this.state.focus) _this.setState({ focus: false });
-        if (_this.props.onBlur) _this.props.onBlur(event);
+        if (_this.props.onBlur) _this.props.onBlur(event, _this.state.active);
       }, _this.handleQueryChange = function (value) {
         _this.setState({ query: value, showAllSuggestions: false });
       }, _this.handleQueryFocus = function () {


### PR DESCRIPTION
I currently have a use case where the current active selection is very useful for my onBlur handler. Don't know if you maybe see some constraints that speak against merging this. Otherwise it would be nice to have it in the main repository :-)