### PR TITLE
fix handleMultipleChange in autocomplete spec

### DIFF
--- a/spec/components/autocomplete.js
+++ b/spec/components/autocomplete.js
@@ -16,7 +16,7 @@ class AutocompleteTest extends React.Component {
       multiple: value,
       countriesObject: {
         ...this.state.countriesObject,
-        ...!this.state.countriesObject[value[0]] ? {[value[0]]: value[0]} : {}
+        ...(value[0] && !this.state.countriesObject[value[0]]) ? {[value[0]]: value[0]} : {}
       }
     });
   };


### PR DESCRIPTION
So, I was just messing around with the spec, when I found this error (see image below). To reproduce it you just have to go to the spec and click on the remove button of both "Spain" and "England" in the first example.

<img width="803" alt="screen shot 2016-10-28 at 18 38 45" src="https://cloud.githubusercontent.com/assets/905225/19814442/7be2619a-9d3e-11e6-8d28-b5ae726ad54d.png">

The problem was on this lines:

```
countriesObject: {
  ...this.state.countriesObject,
  ...!this.state.countriesObject[value[0]] ? {[value[0]]: value[0]} : {}
}
```

When we remove the last item, value is an empty array, so we do `{[value[0]]: value[0]}` we create an undefined key in the countriesObject which breaks in the autocomplete component.
