### PR TITLE
Moves the Autocomplete enter check to onKeyDown to resolve form submit bug

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -116,9 +116,7 @@ const factory = (Chip, Input) => {
      if (shouldClearQuery) {
        this.setState({query: ''});
      }
-   };
-
-   handleQueryKeyUp = (event) => {
+     
      if (event.which === 13) {
        let target = this.state.active;
        if (!target) {
@@ -129,7 +127,9 @@ const factory = (Chip, Input) => {
        }
        this.select(event, target);
      }
+   };
 
+   handleQueryKeyUp = (event) => {
      if (event.which === 27) ReactDOM.findDOMNode(this).querySelector('input').blur();
 
      if ([40, 38].indexOf(event.which) !== -1) {


### PR DESCRIPTION
I've run into a bug with Autocomplete when pressing enter inside of a form. Setup looks like this:

``` javascript
<form onSubmit={/* ... */}>
  <Autocomplete onChange={/* ... */} /* ... */ />
</form>
```

When focusing on the Autocomplete and selecting a suggestion with the enter key, the form submits before the Autocomplete's `onChange` is called. This is because Autocomplete uses its enter check within `keyUp`, where forms are submitted on `keyDown`. Moving the enter check from Autocomplete's `handleQueryKeyUp` into the `handleQueryKeyDown` should fix this issue.

Alternate solutions are to add 

``` javascript
if (keyCode === 13 && this.state.query.length !== 0) {
  event.preventDefault()
}
```

inside of the `handleQueryKeyDown` if having the enter check inside keyUp was deliberate. Another possible solution is just to let the outside developers check themselves with

``` javascript
if (this.props.onKeyDown) this.props.onKeyDown(event)
```

inside of `handleQueryKeyDown`.
