### PR TITLE
remove icon from snackbar

### DIFF
--- a/components/snackbar/Snackbar.js
+++ b/components/snackbar/Snackbar.js
@@ -3,7 +3,6 @@ import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { SNACKBAR } from '../identifiers.js';
 import ActivableRenderer from '../hoc/ActivableRenderer.js';
-import FontIcon from '../font_icon/FontIcon.js';
 import InjectOverlay from '../overlay/Overlay.js';
 import InjectButton from '../button/Button.js';
 
@@ -14,10 +13,6 @@ const factory = (Overlay, Button) => {
       active: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
-      icon: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.element
-      ]),
       label: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.element
@@ -53,7 +48,7 @@ const factory = (Overlay, Button) => {
     }
 
     render () {
-      const {action, active, children, icon, label, onClick, theme, type } = this.props;
+      const {action, active, children, label, onClick, theme, type } = this.props;
       const className = classnames([theme.snackbar, theme[type]], {
         [theme.active]: active
       }, this.props.className);
@@ -61,7 +56,6 @@ const factory = (Overlay, Button) => {
       return (
         <Overlay invisible>
           <div data-react-toolbox='snackbar' className={className}>
-            {icon ? <FontIcon value={icon} className={theme.icon} /> : null}
             <span className={theme.label}>
               {label}
               {children}

--- a/components/snackbar/index.d.ts
+++ b/components/snackbar/index.d.ts
@@ -19,10 +19,6 @@ export interface SnackbarTheme {
    */
   cancel?: string;
   /**
-   * Used for the icon element.
-   */
-  icon?: string;
-  /**
    * Used for the label element.
    */
   label?: string;
@@ -46,10 +42,6 @@ interface SnackbarProps extends ReactToolbox.Props {
    * @default true
    */
   active?: boolean;
-  /**
-   * String key for an icon or Element which will be displayed in left side of the snackbar.
-   */
-  icon?: React.ReactNode | string;
   /**
    * Text to display in the content. Required.
    */

--- a/components/snackbar/readme.md
+++ b/components/snackbar/readme.md
@@ -21,7 +21,6 @@ class SnackbarTest extends React.Component {
         <Button label='Show Snackbar' raised onClick={this.handleClick} />
         <Snackbar
           action='Nice'
-          icon='question_answer'
           label='A new developer started using React Toolbox'
           onClick={this.handleSnackbarClick}
           ref='snackbar'
@@ -43,7 +42,6 @@ This component can be styled by context providing a theme with the key `RTSnackb
 | `active`      | `Boolean`               |  `false`      | If true, the snackbar will be active.|
 | `children`    | `String or Element`     |  `false`      | Text or node to be displayed in the content as alternative to `label`.|
 | `className`   | `String`                | `''`          | Additional class name to provide custom styling.|
-| `icon`        | `String` or `Element`   |               | String key for an icon or Element which will be displayed in left side of the snackbar.|
 | `label`       | `String or Element`     |               | Text to display in the content.|
 | `onClick`     | `Function`              |               | Callback function that will be called when the button action is clicked.|
 | `onTimeout`   | `Function`              |               | Callback function when finish the set timeout.|
@@ -58,7 +56,6 @@ This component can be styled by context providing a theme with the key `RTSnackb
 | `active` | Added to the root element when its active.|
 | `button` | Used for the button inside the component.|
 | `cancel` | Added to the root element in case it's cancel type.|
-| `icon` | Used for the icon element.|
 | `label` | Used for the label element.|
 | `snackbar` | Used as the className for the root element of the component.|
 | `warning` | Added to the root element in case it's warning type.|

--- a/components/snackbar/theme.scss
+++ b/components/snackbar/theme.scss
@@ -35,10 +35,6 @@
   }
 }
 
-.icon {
-  margin-right: $snackbar-vertical-offset;
-}
-
 .label {
   flex-grow: 1;
   font-size: $font-size-small;

--- a/docs/app/components/layout/main/modules/examples/snackbar_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/snackbar_example_1.txt
@@ -24,7 +24,6 @@ class SnackbarTest extends React.Component {
         <Snackbar
           action='Dismiss'
           active={this.state.active}
-          icon='question_answer'
           label='Snackbar action cancel'
           timeout={2000}
           onClick={this.handleSnackbarClick}

--- a/spec/components/snackbar.js
+++ b/spec/components/snackbar.js
@@ -28,7 +28,6 @@ class SnackbarTest extends React.Component {
         <Snackbar
           action='Hide'
           active={this.state.active}
-          icon='question_answer'
           timeout={2000}
           onClick={this.handleSnackbarClick}
           onTimeout={this.handleSnackbarTimeout}


### PR DESCRIPTION
As #918 says, the icon in the is not allowed by the Material Design spec.