### PR TITLE
Add example of multiword icon name

### DIFF
--- a/components/font_icon/readme.md
+++ b/components/font_icon/readme.md
@@ -10,6 +10,7 @@ const FontIcons = () => (
   <span>
     <FontIcon value='add' />
     <FontIcon value='favorite' />
+    <FontIcon value='account_circle' />
     <FontIcon>star</FontIcon>
   </span>
 );

--- a/docs/app/components/layout/main/modules/examples/font_icon_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/font_icon_example_1.txt
@@ -2,6 +2,7 @@ const FontIcons = () => (
   <span>
     <FontIcon value='add' />
     <FontIcon value='favorite' />
+    <FontIcon value='account_circle' />
     <FontIcon>star</FontIcon>
   </span>
 );


### PR DESCRIPTION
The Material UI documentation mentions icon names like "account circle".
It was not documented anywhere that the separator has to be an
underscore: "account_circle".