### PR TITLE
Update instructions for running docs locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ To start the documentation site locally, you'll need to install the dependencies
 
 ```
 $ git clone https://github.com/react-toolbox/react-toolbox.git
+$ cd react-toolbox/
 $ npm install
 $ cd docs/
 $ npm install


### PR DESCRIPTION
The instructions to run the documentation locally does not tell you to cd into the react-toolbox directory after cloning and before running npm install. I have added the instruction