### PR TITLE
Implementing tab pagination per material design specifications.

### DIFF
--- a/components/button/theme.scss
+++ b/components/button/theme.scss
@@ -10,7 +10,7 @@
   > input {
     position: absolute;
     top: 0;
-    left:0;
+    left: 0;
     z-index: 0;
     width: 0.1px;
     height: 0.1px;

--- a/components/tabs/theme.scss
+++ b/components/tabs/theme.scss
@@ -4,15 +4,44 @@
 @import "./config";
 
 .tabs {
-  position: relative;
   display: flex;
   flex-direction: column;
 }
 
 .navigation {
+  position: relative;
   display: flex;
   flex-direction: row;
+  overflow-x: hidden;
   box-shadow: inset 0 -1px $tab-navigation-border-color;
+}
+
+.navigationContainer {
+  display: flex;
+
+  .navigation {
+    flex: 1;
+  }
+}
+
+.arrow {
+  padding: 0 $tab-label-h-padding;
+  color: $tab-text-color;
+
+  &.invisible {
+    visibility: hidden;
+  }
+}
+
+.arrowContainer {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  box-shadow: inset 0 -1px $tab-navigation-border-color;
+
+  &.invisible {
+    display: none;
+  }
 }
 
 .label {
@@ -89,7 +118,7 @@
 }
 
 .inverse {
-  .navigation {
+  .navigation, .arrowContainer {
     background-color: $tab-inverse-bar-color;
   }
 
@@ -98,6 +127,10 @@
     &.active {
       color: $tab-inverse-text-color;
     }
+  }
+
+  .arrow {
+    color: $tab-inverse-text-color;
   }
 
   .pointer {

--- a/lib/button/theme.scss
+++ b/lib/button/theme.scss
@@ -10,7 +10,7 @@
   > input {
     position: absolute;
     top: 0;
-    left:0;
+    left: 0;
     z-index: 0;
     width: 0.1px;
     height: 0.1px;

--- a/lib/tabs/Tabs.js
+++ b/lib/tabs/Tabs.js
@@ -11,9 +11,9 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _classnames2 = require('classnames');
+var _classnames6 = require('classnames');
 
-var _classnames3 = _interopRequireDefault(_classnames2);
+var _classnames7 = _interopRequireDefault(_classnames6);
 
 var _reactCssThemr = require('react-css-themr');
 
@@ -53,7 +53,8 @@ var factory = function factory(Tab, TabContent) {
       }
 
       return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Tabs.__proto__ || Object.getPrototypeOf(Tabs)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
-        pointer: {}
+        pointer: {},
+        arrows: {}
       }, _this.handleHeaderClick = function (event) {
         var idx = parseInt(event.currentTarget.id);
         if (_this.props.onChange) _this.props.onChange(idx);
@@ -64,6 +65,19 @@ var factory = function factory(Tab, TabContent) {
         _this.resizeTimeout = setTimeout(_this.handleResizeEnd, 50);
       }, _this.handleResizeEnd = function () {
         _this.updatePointer(_this.props.index);
+        _this.updateArrows();
+      }, _this.scrollNavigationLeft = function () {
+        var oldScrollLeft = _this.refs.navigation.scrollLeft;
+        _this.refs.navigation.scrollLeft -= _this.refs.navigation.clientWidth;
+        if (_this.refs.navigation.scrollLeft !== oldScrollLeft) {
+          _this.updateArrows();
+        }
+      }, _this.scrollNavigationRight = function () {
+        var oldScrollLeft = _this.refs.navigation.scrollLeft;
+        _this.refs.navigation.scrollLeft += _this.refs.navigation.clientWidth;
+        if (_this.refs.navigation.scrollLeft !== oldScrollLeft) {
+          _this.updateArrows();
+        }
       }, _temp), _possibleConstructorReturn(_this, _ret);
     }
 
@@ -85,6 +99,7 @@ var factory = function factory(Tab, TabContent) {
         window.removeEventListener('resize', this.handleResize);
         clearTimeout(this.resizeTimeout);
         clearTimeout(this.pointerTimeout);
+        clearTimeout(this.arrowsTimeout);
       }
     }, {
       key: 'parseChildren',
@@ -114,13 +129,30 @@ var factory = function factory(Tab, TabContent) {
 
         clearTimeout(this.pointerTimeout);
         this.pointerTimeout = setTimeout(function () {
-          var startPoint = _this3.refs.tabs.getBoundingClientRect().left;
+          var nav = _this3.refs.navigation.getBoundingClientRect();
           var label = _this3.refs.navigation.children[idx].getBoundingClientRect();
+          var scrollLeft = _this3.refs.navigation.scrollLeft;
           _this3.setState({
             pointer: {
-              top: _this3.refs.navigation.getBoundingClientRect().height + 'px',
-              left: label.left - startPoint + 'px',
+              top: nav.height + 'px',
+              left: label.left - nav.left + scrollLeft + 'px',
               width: label.width + 'px'
+            }
+          });
+        }, 20);
+      }
+    }, {
+      key: 'updateArrows',
+      value: function updateArrows() {
+        var _this4 = this;
+
+        clearTimeout(this.arrowsTimeout);
+        this.arrowsTimeout = setTimeout(function () {
+          var nav = _this4.refs.navigation;
+          _this4.setState({
+            arrows: {
+              left: nav.scrollLeft > 0,
+              right: nav.scrollWidth > nav.clientWidth && nav.scrollLeft + nav.clientWidth < nav.scrollWidth
             }
           });
         }, 20);
@@ -128,16 +160,16 @@ var factory = function factory(Tab, TabContent) {
     }, {
       key: 'renderHeaders',
       value: function renderHeaders(headers) {
-        var _this4 = this;
+        var _this5 = this;
 
         return headers.map(function (item, idx) {
           return _react2.default.cloneElement(item, {
             id: idx,
             key: idx,
-            theme: _this4.props.theme,
-            active: _this4.props.index === idx,
+            theme: _this5.props.theme,
+            active: _this5.props.index === idx,
             onClick: function onClick(event) {
-              _this4.handleHeaderClick(event);
+              _this5.handleHeaderClick(event);
               item.props.onClick && item.props.onClick(event);
             }
           });
@@ -146,14 +178,14 @@ var factory = function factory(Tab, TabContent) {
     }, {
       key: 'renderContents',
       value: function renderContents(contents) {
-        var _this5 = this;
+        var _this6 = this;
 
         var contentElements = contents.map(function (item, idx) {
           return _react2.default.cloneElement(item, {
             key: idx,
-            theme: _this5.props.theme,
-            active: _this5.props.index === idx,
-            hidden: _this5.props.index !== idx && _this5.props.hideMode === 'display',
+            theme: _this6.props.theme,
+            active: _this6.props.index === idx,
+            hidden: _this6.props.index !== idx && _this6.props.hideMode === 'display',
             tabIndex: idx
           });
         });
@@ -163,7 +195,7 @@ var factory = function factory(Tab, TabContent) {
         }
 
         return contentElements.filter(function (item, idx) {
-          return idx === _this5.props.index;
+          return idx === _this6.props.index;
         });
       }
     }, {
@@ -181,16 +213,38 @@ var factory = function factory(Tab, TabContent) {
             headers = _parseChildren.headers,
             contents = _parseChildren.contents;
 
-        var classes = (0, _classnames3.default)(theme.tabs, className, (_classnames = {}, _defineProperty(_classnames, theme.fixed, fixed), _defineProperty(_classnames, theme.inverse, inverse), _classnames));
+        var classes = (0, _classnames7.default)(theme.tabs, className, (_classnames = {}, _defineProperty(_classnames, theme.fixed, fixed), _defineProperty(_classnames, theme.inverse, inverse), _classnames));
         return _react2.default.createElement(
           'div',
           { ref: 'tabs', 'data-react-toolbox': 'tabs', className: classes },
           _react2.default.createElement(
-            'nav',
-            { className: theme.navigation, ref: 'navigation' },
-            this.renderHeaders(headers)
+            'div',
+            { className: theme.navigationContainer },
+            _react2.default.createElement(
+              'div',
+              { className: (0, _classnames7.default)(theme.arrowContainer, _defineProperty({}, theme.invisible, !(this.state.arrows.left || this.state.arrows.right))), onClick: this.scrollNavigationLeft },
+              _react2.default.createElement(
+                'span',
+                { className: (0, _classnames7.default)('material-icons', theme.arrow, _defineProperty({}, theme.invisible, !this.state.arrows.left)) },
+                'keyboard_arrow_left'
+              )
+            ),
+            _react2.default.createElement(
+              'nav',
+              { className: theme.navigation, ref: 'navigation' },
+              this.renderHeaders(headers),
+              _react2.default.createElement('span', { className: theme.pointer, style: this.state.pointer })
+            ),
+            _react2.default.createElement(
+              'div',
+              { className: (0, _classnames7.default)(theme.arrowContainer, _defineProperty({}, theme.invisible, !(this.state.arrows.left || this.state.arrows.right))), onClick: this.scrollNavigationRight },
+              _react2.default.createElement(
+                'span',
+                { className: (0, _classnames7.default)('material-icons', theme.arrow, _defineProperty({}, theme.invisible, !this.state.arrows.right)) },
+                'keyboard_arrow_right'
+              )
+            )
           ),
-          _react2.default.createElement('span', { className: theme.pointer, style: this.state.pointer }),
           this.renderContents(contents)
         );
       }

--- a/lib/tabs/theme.scss
+++ b/lib/tabs/theme.scss
@@ -4,15 +4,44 @@
 @import "./config";
 
 .tabs {
-  position: relative;
   display: flex;
   flex-direction: column;
 }
 
 .navigation {
+  position: relative;
   display: flex;
   flex-direction: row;
+  overflow-x: hidden;
   box-shadow: inset 0 -1px $tab-navigation-border-color;
+}
+
+.navigationContainer {
+  display: flex;
+
+  .navigation {
+    flex: 1;
+  }
+}
+
+.arrow {
+  padding: 0 $tab-label-h-padding;
+  color: $tab-text-color;
+
+  &.invisible {
+    visibility: hidden;
+  }
+}
+
+.arrowContainer {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  box-shadow: inset 0 -1px $tab-navigation-border-color;
+
+  &.invisible {
+    display: none;
+  }
 }
 
 .label {
@@ -89,7 +118,7 @@
 }
 
 .inverse {
-  .navigation {
+  .navigation, .arrowContainer {
     background-color: $tab-inverse-bar-color;
   }
 
@@ -98,6 +127,10 @@
     &.active {
       color: $tab-inverse-text-color;
     }
+  }
+
+  .arrow {
+    color: $tab-inverse-text-color;
   }
 
   .pointer {


### PR DESCRIPTION
Our company has many users who frequently rely on views with a lot of tabs or with tab labels that are long.

The current behavior for tab labels is for them to horizontally overflow their container if there are too many.

This pull request aims to resolve this issue by implementing tab pagination. For more information on why I went this route rather than just changing `flex-wrap` or `overflow`, please see the tabs section of the material design specifications (https://material.google.com/components/tabs.html).

Please let me know your thoughts on this.
