### PR TITLE
Adds onQueryChange callback property to Autocomplete

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -26,6 +26,7 @@ const factory = (Chip, Input) => {
      onBlur: PropTypes.func,
      onChange: PropTypes.func,
      onFocus: PropTypes.func,
+     onQueryChange: PropTypes.func,
      selectedPosition: PropTypes.oneOf(['above', 'below']),
      showSuggestionsWhenValueIsSet: PropTypes.bool,
      source: PropTypes.any,
@@ -97,6 +98,7 @@ const factory = (Chip, Input) => {
    };
 
    handleQueryChange = (value) => {
+     if (this.props.onQueryChange) this.props.onQueryChange(value);
      this.setState({query: value, showAllSuggestions: false});
    };
 

--- a/components/autocomplete/index.d.ts
+++ b/components/autocomplete/index.d.ts
@@ -73,6 +73,10 @@ interface AutocompleteProps extends ReactToolbox.Props {
    */
   onChange?: Function;
   /**
+   * Callback function that is fired when the components's query changes.  It is passed the value of the new query.
+   */
+  onQueryChange?: Function;
+  /**
    * Determines if the selected list is shown above or below input. It can be above or below.
    * @default above
    */

--- a/components/autocomplete/readme.md
+++ b/components/autocomplete/readme.md
@@ -53,6 +53,7 @@ If you want to provide a theme via context, the component key is `RTAutocomplete
 | `onBlur`            | `Function`             |                 | Callback function that is fired when component is blurred.|
 | `onChange`          | `Function`             |                 | Callback function that is fired when the components's value changes.|
 | `onFocus`           | `Function`             |                 | Callback function that is fired when component is focused.|
+| `onQueryChange`     | `Function`             |                 | Callback function that is fired when component's query changes, called with the new query value. |
 | `source`            | `Object` or `Array`    |                 | Object of key/values or array representing all items suggested. |
 | `selectedPosition`  | `String`               |  `above`        | Determines if the selected list is shown above or below input. It can be `above` or `below`. |
 | `showSuggestionsWhenValueIsSet` | `Bool`     | `false`         | If true, the list of suggestions will not be filtered when a value is selected, until the query is modified. |

--- a/lib/autocomplete/Autocomplete.js
+++ b/lib/autocomplete/Autocomplete.js
@@ -90,6 +90,7 @@ var factory = function factory(Chip, Input) {
         if (_this.state.focus) _this.setState({ focus: false });
         if (_this.props.onBlur) _this.props.onBlur(event);
       }, _this.handleQueryChange = function (value) {
+        if (_this.props.onQueryChange) _this.props.onQueryChange(value);
         _this.setState({ query: value, showAllSuggestions: false });
       }, _this.handleQueryFocus = function () {
         _this.refs.suggestions.scrollTop = 0;
@@ -440,6 +441,7 @@ var factory = function factory(Chip, Input) {
     onBlur: _react.PropTypes.func,
     onChange: _react.PropTypes.func,
     onFocus: _react.PropTypes.func,
+    onQueryChange: _react.PropTypes.func,
     selectedPosition: _react.PropTypes.oneOf(['above', 'below']),
     showSuggestionsWhenValueIsSet: _react.PropTypes.bool,
     source: _react.PropTypes.any,

--- a/lib/autocomplete/index.d.ts
+++ b/lib/autocomplete/index.d.ts
@@ -73,6 +73,10 @@ interface AutocompleteProps extends ReactToolbox.Props {
    */
   onChange?: Function;
   /**
+   * Callback function that is fired when the components's query changes.  It is passed the value of the new query.
+   */
+  onQueryChange?: Function;
+  /**
    * Determines if the selected list is shown above or below input. It can be above or below.
    * @default above
    */


### PR DESCRIPTION
The onQueryChange callback is called when the value of the query changes in Autocomplete.
It is called with the new query value.