### PR TITLE
Removes onQueryChange from Input props in Autocomplete

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -288,8 +288,8 @@ const factory = (Chip, Input) => {
 
    render () {
      const {
-      allowCreate, error, label, source, suggestionMatch, //eslint-disable-line no-unused-vars
-      selectedPosition, showSuggestionsWhenValueIsSet,    //eslint-disable-line no-unused-vars
+      allowCreate, error, label, onQueryChange, selectedPosition,  //eslint-disable-line no-unused-vars
+      showSuggestionsWhenValueIsSet, source, suggestionMatch,      //eslint-disable-line no-unused-vars
       theme, ...other
     } = this.props;
      const className = classnames(theme.autocomplete, {

--- a/lib/autocomplete/Autocomplete.js
+++ b/lib/autocomplete/Autocomplete.js
@@ -396,12 +396,13 @@ var factory = function factory(Chip, Input) {
             allowCreate = _props.allowCreate,
             error = _props.error,
             label = _props.label,
-            source = _props.source,
-            suggestionMatch = _props.suggestionMatch,
+            onQueryChange = _props.onQueryChange,
             selectedPosition = _props.selectedPosition,
             showSuggestionsWhenValueIsSet = _props.showSuggestionsWhenValueIsSet,
+            source = _props.source,
+            suggestionMatch = _props.suggestionMatch,
             theme = _props.theme,
-            other = _objectWithoutProperties(_props, ['allowCreate', 'error', 'label', 'source', 'suggestionMatch', 'selectedPosition', 'showSuggestionsWhenValueIsSet', 'theme']);
+            other = _objectWithoutProperties(_props, ['allowCreate', 'error', 'label', 'onQueryChange', 'selectedPosition', 'showSuggestionsWhenValueIsSet', 'source', 'suggestionMatch', 'theme']);
 
         var className = (0, _classnames5.default)(theme.autocomplete, _defineProperty({}, theme.focus, this.state.focus), this.props.className);
 


### PR DESCRIPTION
PR #991 introduced the onQueryChange callback property for Autocomplete; however onQueryChange was spread into the Input component which raised a warning regarding onQueryChange not being a property of `<input/>`.

Signed-off-by: Tom Dunlap, Zeno Su <tom@cando.com, zeno@cando.com>