### PR TITLE
Tooltip fixes

### DIFF
--- a/components/tooltip/Tooltip.js
+++ b/components/tooltip/Tooltip.js
@@ -152,7 +152,7 @@ const tooltipFactory = (options = {}) => {
       };
 
       handleMouseEnter = (event) => {
-        this.activate(this.calculatePosition(event.target));
+        this.activate(this.calculatePosition(event.currentTarget));
         if (this.props.onMouseEnter) this.props.onMouseEnter(event);
       };
 
@@ -167,7 +167,7 @@ const tooltipFactory = (options = {}) => {
         }
 
         if (this.props.tooltipShowOnClick && !this.state.active) {
-          this.activate(this.calculatePosition(event.target));
+          this.activate(this.calculatePosition(event.currentTarget));
         }
 
         if (this.props.onClick) this.props.onClick(event);

--- a/components/tooltip/Tooltip.js
+++ b/components/tooltip/Tooltip.js
@@ -193,6 +193,8 @@ const tooltipFactory = (options = {}) => {
           [theme[positionClass]]: theme[positionClass]
         });
 
+        const isNative = typeof ComposedComponent === 'string';
+
         return (
           <ComposedComponent
             {...other}
@@ -200,7 +202,7 @@ const tooltipFactory = (options = {}) => {
             onClick={this.handleClick}
             onMouseEnter={this.handleMouseEnter}
             onMouseLeave={this.handleMouseLeave}
-            theme={theme}
+            {...isNative ? {} : {theme}}
           >
             {children ? children : null}
             {visible && (

--- a/spec/components/tooltip.js
+++ b/spec/components/tooltip.js
@@ -9,6 +9,7 @@ const TooltipStrong = Tooltip(({children, ...other}) => {
   delete other.theme;
   return <strong {...other}>{children}</strong>;
 });
+const TooltipStrongDirect = Tooltip('strong');
 
 const TooltipTest = () => (
   <section>
@@ -27,9 +28,9 @@ const TooltipTest = () => (
     <p>
       Click this next word to show and hide on click:
       {' '}
-      <TooltipStrong tooltip='This is a auto show tooltip' tooltipShowOnClick>
+      <TooltipStrongDirect tooltip='This is a auto show tooltip' tooltipShowOnClick>
         oh hai
-      </TooltipStrong>
+      </TooltipStrongDirect>
       {' '}. This is useful for mobile!
     </p>
   </section>

--- a/spec/components/tooltip.js
+++ b/spec/components/tooltip.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Button from '../../components/button';
 import Input from '../../components/input';
 import Tooltip from '../../components/tooltip';
+import Chip from '../../components/chip';
+import Avatar from '../../components/avatar';
 
 const TooltipButton = Tooltip(Button);
 const TooltipInput = Tooltip(Input);
@@ -10,6 +12,7 @@ const TooltipStrong = Tooltip(({children, ...other}) => {
   return <strong {...other}>{children}</strong>;
 });
 const TooltipStrongDirect = Tooltip('strong');
+const ChipTooltip = Tooltip(Chip);
 
 const TooltipTest = () => (
   <section>
@@ -23,6 +26,10 @@ const TooltipTest = () => (
       floating
       tooltip={<div><p>An example with</p><p>Multiline!</p></div>}
     />
+    <ChipTooltip tooltip='Dolor sit amet' tooltipPosition='top'>
+      <Avatar icon='home'/>
+      <span>Tooltip in a chip</span>
+    </ChipTooltip>
     <TooltipInput tooltip='lorem ipsum...' />
     <p>Lorem ipsum dolor sit amet, <TooltipStrong tooltip='This is a auto show tooltip'>consectetur</TooltipStrong> adipiscing elit.</p>
     <p>


### PR DESCRIPTION
- When creating a tooltipped component sometimes you might want to add a tooltip into a simple native component, which throws an error when it tries to pass the `theme` prop. Now creating a tooltip like `const TooltippedDiv = Tooltip('div')` works as expected.
- The tooltip now uses the DOM node of `currentTarget` instead of `target` when calculating the position. This makes the tooltip centered in the correct place when adding it to a component that has multiple children in different positions.