### PR TITLE
Autocomplete isValueAnObject cleanup

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -68,19 +68,11 @@ const factory = (Chip, Input) => {
      isValueAnObject: false
    };
 
-   componentDidMount () {
-     this.setIsValueAnObject();
-   }
-
    componentWillReceiveProps (nextProps) {
      if (!this.props.multiple) {
        this.setState({
          query: this.query(nextProps.value)
        });
-     }
-
-     if (nextProps.multiple && this.props.value !== nextProps.value) {
-        this.setIsValueAnObject();
      }
    }
 
@@ -251,7 +243,7 @@ const factory = (Chip, Input) => {
 
      if (!vals) vals = [];
 
-     if (this.props.showSelectedWhenNotInSource && this.state.isValueAnObject) {
+     if (this.props.showSelectedWhenNotInSource && this.isValueAnObject()) {
        return new Map(Object.entries(vals));
      }
 
@@ -271,7 +263,7 @@ const factory = (Chip, Input) => {
      const source = this.source();
      const newValue = target === void 0 ? event.target.id : target;
 
-     if (this.state.isValueAnObject) {
+     if (this.isValueAnObject()) {
        const newItem = Array.from(source).reduce((obj, [k, value]) => {
          if (k === newValue) {
            obj[k] = value;
@@ -291,7 +283,7 @@ const factory = (Chip, Input) => {
 
        values.delete(key);
 
-       if (this.state.isValueAnObject) {
+       if (this.isValueAnObject()) {
          return this.handleChange(this.mapToObject(values), event);
        }
 
@@ -299,10 +291,8 @@ const factory = (Chip, Input) => {
      }
    }
 
-   setIsValueAnObject () {
-      this.setState({
-        isValueAnObject: !Array.isArray(this.props.value) && typeof this.props.value === 'object'
-      });
+    isValueAnObject () {
+      return !Array.isArray(this.props.value) && typeof this.props.value === 'object';
     }
 
     mapToObject (map) {

--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -291,16 +291,16 @@ const factory = (Chip, Input) => {
      }
    }
 
-    isValueAnObject () {
+   isValueAnObject () {
       return !Array.isArray(this.props.value) && typeof this.props.value === 'object';
-    }
+   }
 
-    mapToObject (map) {
+   mapToObject (map) {
       return Array.from(map).reduce((obj, [k, value]) => {
         obj[k] = value;
         return obj;
       }, {});
-    }
+   }
 
    renderSelected () {
      if (this.props.multiple) {


### PR DESCRIPTION
Cleans up the isValueAnObject logic. I thought `this.props.value` was being converted when I initially wrote this.

I was finding sometimes `this.state.isValueAnObject` wasn't being set correctly intermittently so this fixes that too.