### PR TITLE
Add ability to sort a data table by clicking a table heading

### DIFF
--- a/components/table/Table.js
+++ b/components/table/Table.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { TABLE } from '../identifiers.js';
 import InjectCheckbox from '../checkbox/Checkbox.js';
+import InjectFontIcon from '../font_icon/FontIcon.js';
 import tableHeadFactory from './TableHead.js';
 import tableRowFactory from './TableRow.js';
 
@@ -18,6 +19,8 @@ const factory = (TableHead, TableRow) => {
       onSelect: PropTypes.func,
       selectable: PropTypes.bool,
       selected: PropTypes.array,
+      sortColumn: PropTypes.string,
+      sortDirection: PropTypes.string,
       source: PropTypes.array,
       theme: PropTypes.shape({
         table: PropTypes.string
@@ -70,7 +73,7 @@ const factory = (TableHead, TableRow) => {
 
     renderHead () {
       if (this.props.heading) {
-        const {model, selected, source, selectable, multiSelectable} = this.props;
+        const {model, selected, source, selectable, multiSelectable, sortColumn, sortDirection} = this.props;
         const isSelected = selected.length === source.length;
         return (
           <TableHead
@@ -79,6 +82,8 @@ const factory = (TableHead, TableRow) => {
             selectable={selectable}
             multiSelectable={multiSelectable}
             selected={isSelected}
+            sortColumn={sortColumn}
+            sortDirection={sortDirection}
             theme={this.props.theme}
           />
         );
@@ -121,7 +126,7 @@ const factory = (TableHead, TableRow) => {
   return Table;
 };
 
-const TableHead = tableHeadFactory(InjectCheckbox);
+const TableHead = tableHeadFactory(InjectCheckbox, InjectFontIcon);
 const TableRow = tableRowFactory(InjectCheckbox);
 const Table = factory(TableHead, TableRow);
 

--- a/components/table/TableHead.js
+++ b/components/table/TableHead.js
@@ -1,11 +1,25 @@
 import React, { PropTypes } from 'react';
 
-const factory = (Checkbox) => {
-  const TableHead = ({model, onSelect, selectable, multiSelectable, selected, theme}) => {
+const factory = (Checkbox, FontIcon) => {
+  const TableHead = ({model, onSelect, selectable, multiSelectable, selected, theme, sortColumn, sortDirection}) => {
     let selectCell;
     const contentCells = Object.keys(model).map((key) => {
       const name = model[key].title || key;
-      return <th key={key}>{name}</th>;
+      const onClick = model[key].onClick;
+      return (
+        <th
+          key={key}
+          className={onClick && theme.clickable}
+          onClick={onClick}>
+          {sortColumn === key && sortDirection === 'asc'
+            && <FontIcon value="arrow_upward" className={theme.ascIcon} />
+          }
+          {sortColumn === key && sortDirection === 'desc'
+            && <FontIcon value="arrow_downward" className={theme.descIcon} />
+          }
+          {name}
+        </th>
+      );
     });
 
     if (selectable && multiSelectable) {
@@ -33,6 +47,8 @@ const factory = (Checkbox) => {
     onSelect: PropTypes.func,
     selectable: PropTypes.bool,
     selected: PropTypes.bool,
+    sortColumn: PropTypes.string,
+    sortDirection: PropTypes.string,
     theme: PropTypes.shape({
       selectable: PropTypes.string
     })

--- a/components/table/index.js
+++ b/components/table/index.js
@@ -1,13 +1,14 @@
 import { themr } from 'react-css-themr';
 import { TABLE } from '../identifiers.js';
 import { Checkbox } from '../checkbox';
+import { FontIcon } from '../font_icon';
 import { tableFactory } from './Table.js';
 import tableHeadFactory from './TableHead.js';
 import tableRowFactory from './TableRow.js';
 import theme from './theme.scss';
 
 const applyTheme = (Component) => themr(TABLE, theme)(Component);
-const ThemedTableHead = applyTheme(tableHeadFactory(Checkbox));
+const ThemedTableHead = applyTheme(tableHeadFactory(Checkbox, FontIcon));
 const ThemedTableRow = applyTheme(tableRowFactory(Checkbox));
 const ThemedTable = applyTheme(tableFactory(ThemedTableHead, ThemedTableRow));
 

--- a/components/table/theme.scss
+++ b/components/table/theme.scss
@@ -54,6 +54,28 @@
   background-color: $table-row-highlight;
 }
 
+.clickable {
+  position: relative;
+
+  cursor: pointer;
+}
+
 .editable > * {
   cursor: pointer;
+}
+
+// NOTE Vertically centered in tall headings
+.ascIcon, .descIcon {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -4px;
+
+  display: flex;
+  align-items: center;
+
+  font-size: $font-size-normal;
+  color: $color-text-secondary;
+
+  vertical-align: "middle";
 }


### PR DESCRIPTION
Adds the ability to sort columns by clicking the table header. Accepts an `onClick` in the model, which will make the column clickable. Then, you can pass `props.sortColumn` and `props.sortDirection` into the `<Table />` to get the up/down icon to display.