### PR TITLE
Slider debounced

### DIFF
--- a/components/slider/Slider.js
+++ b/components/slider/Slider.js
@@ -7,11 +7,15 @@ import events from '../utils/events.js';
 import utils from '../utils/utils.js';
 import InjectProgressBar from '../progress_bar/ProgressBar.js';
 import InjectInput from '../input/Input.js';
+import debounce from 'lodash.debounce';
 
 const factory = (ProgressBar, Input) => {
   class Slider extends Component {
     static propTypes = {
       className: PropTypes.string,
+      debounced: PropTypes.bool,
+      debouncedWait: PropTypes.number,
+      debouncedMaxWait: PropTypes.number,
       disabled: PropTypes.bool,
       editable: PropTypes.bool,
       max: PropTypes.number,
@@ -40,6 +44,9 @@ const factory = (ProgressBar, Input) => {
 
     static defaultProps = {
       className: '',
+      debounced: false,
+      debouncedMaxWait: 200,
+      debouncedWait: 32,
       editable: false,
       max: 100,
       min: 0,
@@ -109,10 +116,15 @@ const factory = (ProgressBar, Input) => {
       events.pauseEvent(event);
     };
 
-    handleMouseMove = (event) => {
-      events.pauseEvent(event);
-      this.move(events.getMousePosition(event));
-    };
+    handleMouseMove = this.props.debounced ?
+      debounce((event) => {
+        events.pauseEvent(event);
+        this.move(events.getMousePosition(event));
+      }, this.props.debouncedWait, {maxWait: this.props.debouncedMaxWait}) :
+      (event) => {
+        events.pauseEvent(event);
+        this.move(events.getMousePosition(event));
+      };
 
     handleMouseUp = () => {
       this.end(this.getMouseEventMap());
@@ -136,9 +148,13 @@ const factory = (ProgressBar, Input) => {
       this.end(this.getTouchEventMap());
     };
 
-    handleTouchMove = (event) => {
-      this.move(events.getTouchPosition(event));
-    };
+    handleTouchMove = this.props.debounced ?
+      debounce((event) => {
+        this.move(events.getTouchPosition(event));
+      }, this.props.debouncedWait, {maxWait: this.props.debouncedMaxWait}) :
+      (event) => {
+        this.move(events.getTouchPosition(event));
+      };
 
     handleTouchStart = (event) => {
       if (this.state.inputFocused) this.getInput().blur();

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "core-js": "^2.4.0",
+    "lodash.debounce": "^4.0.8",
     "normalize.css": "^4.2.0",
     "react-css-themr": "^1.6.0"
   },

--- a/spec/components/slider.js
+++ b/spec/components/slider.js
@@ -23,6 +23,8 @@ class SliderTest extends React.Component {
         <Slider pinned snaps min={0} max={10} step={2} editable value={this.state.slider3} onChange={this.handleChange.bind(this, 'slider3')} />
         <p>Disabled status</p>
         <Slider disabled pinned snaps min={0} max={10} step={2} editable value={this.state.slider3} onChange={this.handleChange.bind(this, 'slider3')} />
+        <p>Debounded slider</p>
+        <Slider debounced value={this.state.slider1} onChange={this.handleChange.bind(this, 'slider1')} />
       </section>
     );
   }


### PR DESCRIPTION
Give the possibility to debounce touchmove and mousemove events using lodash.debounce. Useful when using the Slider with not-so-new mobile devices.