### PR TITLE
Fix typeof check in isBrowser function

### DIFF
--- a/components/utils/is-browser.js
+++ b/components/utils/is-browser.js
@@ -1,3 +1,3 @@
 export default function isBrowser () {
-  return typeof window !== undefined && window.document;
+  return typeof window !== 'undefined' && window.document;
 }


### PR DESCRIPTION
This change fixes a small issue with the isBrowser check. Rather than checking for undefined we should check for the string 'undefined', as the typeof operator always returns a string indicating the type of the operand.