### PR TITLE
Babel-polyfill activation to specs

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -8,6 +8,7 @@ module.exports = {
   devtool: 'cheap-module-eval-source-map',
   entry: [
     'webpack-hot-middleware/client',
+    'babel-polyfill',
     './spec/index.js'
   ],
   output: {


### PR DESCRIPTION
This is a tiny change which enables polyfill in specs context. It enables specs rendering with Safari (tested with version 10.0.2. Crashed to Object.entries() call in Autocomplete component) and IE (tested with 10 and 11. Had troubles with String.prototype.startsWith() calls).