### PR TITLE
Fix tabs pointer position

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -54,6 +54,7 @@ const factory = (Tab, TabContent, FontIcon) => {
     componentWillUnmount () {
       window.removeEventListener('resize', this.handleResize);
       clearTimeout(this.resizeTimeout);
+      clearTimeout(this.updatePointerTimeout);
     }
 
     handleHeaderClick = (event) => {
@@ -73,11 +74,18 @@ const factory = (Tab, TabContent, FontIcon) => {
       if (this.navigationNode && this.navigationNode.children[idx]) {
         const nav = this.navigationNode.getBoundingClientRect();
         const label = this.navigationNode.children[idx].getBoundingClientRect();
+        const pointerContainer = this.pointerContainer.getBoundingClientRect();
         const scrollLeft = this.navigationNode.scrollLeft;
+
+        let diff = 0;
+
+        if (scrollLeft > 0 && nav.left > pointerContainer.left) {
+          diff += nav.left - pointerContainer.left;
+        }
+
         this.setState({
           pointer: {
-            top: `${nav.height}px`,
-            left: `${label.left - nav.left + scrollLeft}px`,
+            left: `${label.left - nav.left + diff}px`,
             width: `${label.width}px`
           }
         });
@@ -100,6 +108,9 @@ const factory = (Tab, TabContent, FontIcon) => {
       this.navigationNode.scrollLeft += factor * this.navigationNode.clientWidth;
       if (this.navigationNode.scrollLeft !== oldScrollLeft) {
         this.updateArrows();
+        this.updatePointerTimeout = setTimeout(() => {
+          this.updatePointer(this.props.index);
+        }, 100);
       }
     }
 
@@ -179,11 +190,13 @@ const factory = (Tab, TabContent, FontIcon) => {
             </div>}
             <nav className={theme.navigation} ref={node => {this.navigationNode = node; }}>
               {this.renderHeaders(headers)}
-              <span className={classNamePointer} style={this.state.pointer} />
             </nav>
             {hasRightArrow && <div className={theme.arrowContainer} onClick={this.scrollLeft}>
               <FontIcon className={theme.arrow} value="keyboard_arrow_right" />
             </div>}
+            <div className={theme.pointerContainer} ref={node => {this.pointerContainer = node; }}>
+              <span className={classNamePointer} style={this.state.pointer} />
+            </div>
           </div>
           {this.renderContents(contents)}
         </div>

--- a/components/tabs/theme.scss
+++ b/components/tabs/theme.scss
@@ -17,6 +17,7 @@
 }
 
 .navigationContainer {
+  position: relative;
   display: flex;
 
   .navigation {
@@ -83,11 +84,21 @@
   line-height: $tab-icon-height;
 }
 
+.pointerContainer {
+  position: absolute;
+  top: auto;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: $tab-pointer-height;
+  overflow: hidden;
+}
+
 .pointer {
   position: absolute;
   width: 0;
   height: $tab-pointer-height;
-  margin-top: - $tab-pointer-height;
   background-color: $tab-pointer-color;
   transition-timing-function: $animation-curve-default;
   transition-duration: $animation-duration;


### PR DESCRIPTION
This is the first draft, as described in https://github.com/react-toolbox/react-toolbox/issues/1084#issuecomment-269249082 it changes the HTML structure and the CSS + adds a new method of computing the pointer position. I'd love to find a better solution without another `ref` but I have no other ideas now.

This brings a small issue, because the pointer was moved out of the `nav`, it now appears over the scroller buttons:
![image](https://cloud.githubusercontent.com/assets/1718341/21499007/b448e628-cc3a-11e6-9df5-eb7999461374.png)

