### PR TITLE
Fix right arrow appearing when window is re-sized

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -85,14 +85,20 @@ const factory = (Tab, TabContent, FontIcon) => {
     }
 
     updateArrows = () => {
-      const nav = this.navigationNode;
-      this.setState({
-        arrows: {
-          left: nav.scrollLeft > 0,
-          right: nav.scrollWidth > nav.clientWidth
-            && (nav.scrollLeft + nav.clientWidth) < nav.scrollWidth
-        }
-      });
+      const idx = this.navigationNode.children.length - 2;
+
+      if (idx >= 0) {
+        const scrollLeft = this.navigationNode.scrollLeft;
+        const nav = this.navigationNode.getBoundingClientRect();
+        const lastLabel = this.navigationNode.children[idx].getBoundingClientRect();
+
+        this.setState({
+          arrows: {
+            left: scrollLeft > 0,
+            right: nav.right < (lastLabel.right - 5)
+          }
+        });
+      }
     }
 
     scrollNavigation = (factor) => {


### PR DESCRIPTION
As per https://github.com/react-toolbox/react-toolbox/issues/1084#issuecomment-269317228 and the previous pull request https://github.com/react-toolbox/react-toolbox/pull/1087 I've decided to have a closer look on how updateArrows sets the `arrows.right` to `true`. Here's another solution which is less invasive and solves the issue with right arrow appearing on `fixed` tabs when resizing and the last tab is selected.