### PR TITLE
Minimize bundle size because of ramda

### DIFF
--- a/components/ripple/Ripple.js
+++ b/components/ripple/Ripple.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
-import { dissoc } from 'ramda';
+import dissoc from 'ramda/src/dissoc';
 import { RIPPLE } from '../identifiers.js';
 import events from '../utils/events';
 import prefixer from '../utils/prefixer';

--- a/components/utils/utils.js
+++ b/components/utils/utils.js
@@ -1,4 +1,8 @@
-import { assoc, compose, keys, reduce, pickBy } from 'ramda';
+import assoc from 'ramda/src/assoc';
+import compose from 'ramda/src/compose';
+import keys from 'ramda/src/keys';
+import reduce from 'ramda/src/reduce';
+import pickBy from 'ramda/src/pickBy';
 
 export const angleFromPositions = (cx, cy, ex, ey) => {
   const theta = Math.atan2(ey - cy, ex - cx) + Math.PI / 2;


### PR DESCRIPTION
Import from ramda using the `import XXX from "ramda/src/XXX"` pattern so that bundle sizes will be smaller for not including the whole ramda package (see https://github.com/react-toolbox/react-toolbox/issues/1090).