### PR TITLE
feat(a11y): improve accessibility for iconMenu component

### DIFF
--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -9,6 +9,7 @@ const factory = (ripple, FontIcon) => {
   class IconButton extends Component {
     static propTypes = {
       accent: PropTypes.bool,
+      ariaControls: PropTypes.string,
       children: PropTypes.node,
       className: PropTypes.string,
       disabled: PropTypes.bool,
@@ -28,7 +29,6 @@ const factory = (ripple, FontIcon) => {
     };
 
     static defaultProps = {
-      label: '',
       accent: false,
       className: '',
       neutral: true,
@@ -47,7 +47,7 @@ const factory = (ripple, FontIcon) => {
     };
 
     render () {
-      const {accent, children, className, href, icon, inverse, label, neutral,
+      const {accent, ariaControls, children, className, href, icon, inverse, label, neutral,
         primary, theme, type, ...others} = this.props;
       const element = href ? 'a' : 'button';
       const level = primary ? 'primary' : accent ? 'accent' : 'neutral';
@@ -60,6 +60,7 @@ const factory = (ripple, FontIcon) => {
         ...others,
         href,
         ref: 'button',
+        'aria-controls': ariaControls,
         'aria-label': label,
         className: classes,
         disabled: this.props.disabled,

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -18,6 +18,7 @@ const factory = (ripple, FontIcon) => {
         PropTypes.element
       ]),
       inverse: PropTypes.bool,
+      label: PropTypes.string,
       neutral: PropTypes.bool,
       onMouseLeave: PropTypes.func,
       onMouseUp: PropTypes.func,
@@ -27,6 +28,7 @@ const factory = (ripple, FontIcon) => {
     };
 
     static defaultProps = {
+      label: '',
       accent: false,
       className: '',
       neutral: true,
@@ -45,7 +47,7 @@ const factory = (ripple, FontIcon) => {
     };
 
     render () {
-      const {accent, children, className, href, icon, inverse, neutral,
+      const {accent, children, className, href, icon, inverse, label, neutral,
         primary, theme, type, ...others} = this.props;
       const element = href ? 'a' : 'button';
       const level = primary ? 'primary' : accent ? 'accent' : 'neutral';
@@ -58,6 +60,7 @@ const factory = (ripple, FontIcon) => {
         ...others,
         href,
         ref: 'button',
+        'aria-label': label,
         className: classes,
         disabled: this.props.disabled,
         onMouseUp: this.handleMouseUp,

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -10,6 +10,7 @@ const factory = (ripple, FontIcon) => {
     static propTypes = {
       accent: PropTypes.bool,
       ariaControls: PropTypes.string,
+      ariaExpanded: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
       disabled: PropTypes.bool,
@@ -47,7 +48,7 @@ const factory = (ripple, FontIcon) => {
     };
 
     render () {
-      const {accent, ariaControls, children, className, href, icon, inverse, label, neutral,
+      const {accent, ariaControls, ariaExpanded, children, className, href, icon, inverse, label, neutral,
         primary, theme, type, ...others} = this.props;
       const element = href ? 'a' : 'button';
       const level = primary ? 'primary' : accent ? 'accent' : 'neutral';
@@ -60,6 +61,7 @@ const factory = (ripple, FontIcon) => {
         ...others,
         href,
         ref: 'button',
+        'aria-expanded': ariaExpanded,
         'aria-controls': ariaControls,
         'aria-label': label,
         className: classes,

--- a/components/button/readme.md
+++ b/components/button/readme.md
@@ -38,6 +38,8 @@ If you want to provide a theme via context, the component key is `RTButton`.
 | Name              | Type                  | Default     | Description|
 |:-----|:-----|:-----|:-----|
 | `accent`          | `Boolean`             | `false`     | Indicates if the button should have accent color.|
+| `ariaControls`          | `String`             |      | Indicates the ID of the element which controls.|
+| `ariaExpanded`          | `Boolean`             |     | Indicates if the button has an element opened or not.|
 | `className`       | `String`              | `''`        | Set a class to style the Component.|
 | `disabled`        | `Boolean`             | `false`     | If true, component will be disabled.|
 | `flat`            | `Boolean`             | `false`     | If true, the button will have a flat look. |

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -58,7 +58,7 @@ const factory = (IconButton, Menu) => {
     handleMenuHide = () => {
       this.setState({ active: false });
       if (this.props.onHide) this.props.onHide();
-    }
+    };
 
     render () {
       const menuId = 'Menu' + this.generateID(7);
@@ -77,7 +77,6 @@ const factory = (IconButton, Menu) => {
             ripple={iconRipple}
           />
           <Menu
-            hidden={true}
             menuId={menuId}
             autofocus={autofocus}
             active={this.state.active}

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -19,6 +19,7 @@ const factory = (IconButton, Menu) => {
       label: PropTypes.string,
       menuRipple: PropTypes.bool,
       onClick: PropTypes.func,
+      onEscKeyDown: PropTypes.func,
       onHide: PropTypes.func,
       onSelect: PropTypes.func,
       onShow: PropTypes.func,
@@ -50,6 +51,13 @@ const factory = (IconButton, Menu) => {
       return Math.random().toString(36).substr(2, len)
     };
 
+    handleEscKey = (e) => {
+      if (this.state.active && this.props.onEscKeyDown && e.which === 27) {
+        this.setState({ active: !this.state.active });
+        this.props.onEscKeyDown(e);
+      }
+    };
+
     handleButtonClick = (event) => {
       this.setState({ active: !this.state.active });
       if (this.props.onClick) this.props.onClick(event);
@@ -58,16 +66,30 @@ const factory = (IconButton, Menu) => {
     handleMenuHide = () => {
       this.setState({ active: false });
       if (this.props.onHide) this.props.onHide();
+      document.body.removeEventListener('keydown', this.handleEscKey);
+      this.refs.iconmenu.firstChild.focus();
     };
 
-    render () {
+    componentWillUpdate () {
+      document.body.addEventListener('keydown', this.handleEscKey);
+    };
+
+    componentDidMount () {
+      document.body.addEventListener('keydown', this.handleEscKey);
+    };
+
+    componentWillUnmount () {
+      document.body.removeEventListener('keydown', this.handleEscKey);
+    };
+
+    render() {
       const menuId = 'Menu' + this.generateID(7);
       const {
-        autofocus, children, className, icon, iconRipple, label, menuRipple, onHide, // eslint-disable-line
+        autofocus, children, className, icon, iconRipple, label, menuRipple, onHide, onEscKeyDown, // eslint-disable-line
         onSelect, onShow, position, selectable, selected, theme, ...other
       } = this.props;
       return (
-        <div {...other} className={classnames(theme.iconMenu, className)}>
+        <div ref="iconmenu" {...other} className={classnames(theme.iconMenu, className)}>
           <IconButton
             ariaControls={menuId}
             ariaExpanded={this.state.active}
@@ -76,7 +98,7 @@ const factory = (IconButton, Menu) => {
             icon={icon}
             onClick={this.handleButtonClick}
             ripple={iconRipple}
-          />
+            />
           <Menu
             menuId={menuId}
             autofocus={autofocus}
@@ -89,7 +111,7 @@ const factory = (IconButton, Menu) => {
             selectable={selectable}
             selected={selected}
             theme={theme}
-          >
+            >
             {children}
           </Menu>
         </div>

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -46,6 +46,10 @@ const factory = (IconButton, Menu) => {
       active: false
     }
 
+    generateID = (len) => {
+      return Math.random().toString(36).substr(2, len)
+    };
+
     handleButtonClick = (event) => {
       this.setState({ active: !this.state.active });
       if (this.props.onClick) this.props.onClick(event);
@@ -57,6 +61,7 @@ const factory = (IconButton, Menu) => {
     }
 
     render () {
+      const menuId = 'Menu' + this.generateID(7);
       const {
         autofocus, children, className, icon, iconRipple, label, menuRipple, onHide, // eslint-disable-line
         onSelect, onShow, position, selectable, selected, theme, ...other
@@ -64,6 +69,7 @@ const factory = (IconButton, Menu) => {
       return (
         <div {...other} className={classnames(theme.iconMenu, className)}>
           <IconButton
+            ariaControls={menuId}
             label={label}
             className={theme.icon}
             icon={icon}
@@ -71,6 +77,7 @@ const factory = (IconButton, Menu) => {
             ripple={iconRipple}
           />
           <Menu
+            menuId={menuId}
             autofocus={autofocus}
             active={this.state.active}
             onHide={this.handleMenuHide}

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -15,6 +15,7 @@ const factory = (IconButton, Menu) => {
         PropTypes.element
       ]),
       iconRipple: PropTypes.bool,
+      label: PropTypes.string,
       menuRipple: PropTypes.bool,
       onClick: PropTypes.func,
       onHide: PropTypes.func,
@@ -31,6 +32,7 @@ const factory = (IconButton, Menu) => {
 
     static defaultProps = {
       className: '',
+      label: '',
       icon: 'more_vert',
       iconRipple: true,
       menuRipple: true,
@@ -54,12 +56,13 @@ const factory = (IconButton, Menu) => {
 
     render () {
       const {
-        children, className, icon, iconRipple, menuRipple, onHide, // eslint-disable-line
+        children, className, icon, iconRipple, label, menuRipple, onHide, // eslint-disable-line
         onSelect, onShow, position, selectable, selected, theme, ...other
       } = this.props;
       return (
         <div {...other} className={classnames(theme.iconMenu, className)}>
           <IconButton
+            label={label}
             className={theme.icon}
             icon={icon}
             onClick={this.handleButtonClick}

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -47,8 +47,20 @@ const factory = (IconButton, Menu) => {
       active: false
     }
 
+    componentDidMount () {
+      document.body.addEventListener('keydown', this.handleEscKey);
+    }
+
+    componentWillUpdate () {
+      document.body.addEventListener('keydown', this.handleEscKey);
+    }
+
+    componentWillUnmount () {
+      document.body.removeEventListener('keydown', this.handleEscKey);
+    }
+
     generateID = (len) => {
-      return Math.random().toString(36).substr(2, len)
+      return Math.random().toString(36).substr(2, len);
     };
 
     handleEscKey = (e) => {
@@ -70,19 +82,7 @@ const factory = (IconButton, Menu) => {
       this.refs.iconmenu.firstChild.focus();
     };
 
-    componentWillUpdate () {
-      document.body.addEventListener('keydown', this.handleEscKey);
-    };
-
-    componentDidMount () {
-      document.body.addEventListener('keydown', this.handleEscKey);
-    };
-
-    componentWillUnmount () {
-      document.body.removeEventListener('keydown', this.handleEscKey);
-    };
-
-    render() {
+    render () {
       const menuId = 'Menu' + this.generateID(7);
       const {
         autofocus, children, className, icon, iconRipple, label, menuRipple, onHide, onEscKeyDown, // eslint-disable-line

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -70,6 +70,7 @@ const factory = (IconButton, Menu) => {
         <div {...other} className={classnames(theme.iconMenu, className)}>
           <IconButton
             ariaControls={menuId}
+            ariaExpanded={this.state.active}
             label={label}
             className={theme.icon}
             icon={icon}

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -8,6 +8,7 @@ import InjectMenu from './Menu.js';
 const factory = (IconButton, Menu) => {
   class IconMenu extends Component {
     static propTypes = {
+      autofocus: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
       icon: PropTypes.oneOfType([
@@ -31,6 +32,7 @@ const factory = (IconButton, Menu) => {
     };
 
     static defaultProps = {
+      autofocus: true,
       className: '',
       label: '',
       icon: 'more_vert',
@@ -56,7 +58,7 @@ const factory = (IconButton, Menu) => {
 
     render () {
       const {
-        children, className, icon, iconRipple, label, menuRipple, onHide, // eslint-disable-line
+        autofocus, children, className, icon, iconRipple, label, menuRipple, onHide, // eslint-disable-line
         onSelect, onShow, position, selectable, selected, theme, ...other
       } = this.props;
       return (
@@ -69,6 +71,7 @@ const factory = (IconButton, Menu) => {
             ripple={iconRipple}
           />
           <Menu
+            autofocus={autofocus}
             active={this.state.active}
             onHide={this.handleMenuHide}
             onSelect={onSelect}

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -77,6 +77,7 @@ const factory = (IconButton, Menu) => {
             ripple={iconRipple}
           />
           <Menu
+            hidden={true}
             menuId={menuId}
             autofocus={autofocus}
             active={this.state.active}

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -18,11 +18,11 @@ const POSITION = {
 const factory = (MenuItem) => {
   class Menu extends Component {
     static propTypes = {
-      menuId: PropTypes.string,
-      autofocus: PropTypes.bool,
       active: PropTypes.bool,
+      autofocus: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
+      menuId: PropTypes.string,
       onHide: PropTypes.func,
       onSelect: PropTypes.func,
       onShow: PropTypes.func,
@@ -209,12 +209,12 @@ const factory = (MenuItem) => {
 
     show () {
       const { width, height } = this.refs.menu.getBoundingClientRect();
-      let listenerTransition = () => {
+      const listenerTransition = () => {
         this.setFocus();
         this.refs.menu.removeEventListener('transitionend', listenerTransition);
       };
       this.setState({active: true, width, height});
-      if(this.props.autofocus) {
+      if (this.props.autofocus) {
         this.refs.menu.addEventListener('transitionend', listenerTransition);
       }
     }
@@ -231,7 +231,7 @@ const factory = (MenuItem) => {
         [theme.rippled]: this.state.rippled
       }, this.props.className);
 
-      if(this.props.menuId) {
+      if (this.props.menuId) {
         return (
           <div id={this.props.menuId} aria-hidden={!this.props.active} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
             {this.props.outline ? <div className={theme.outline} style={outlineStyle} /> : null}

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -211,7 +211,7 @@ const factory = (MenuItem) => {
       const { width, height } = this.refs.menu.getBoundingClientRect();
       let listenerTransition = () => {
         this.setFocus();
-        this.refs.menu.removeEventListener(listenerTransition);
+        this.refs.menu.removeEventListener('transitionend', listenerTransition);
       };
       this.setState({active: true, width, height});
       if(this.props.autofocus) {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -23,7 +23,6 @@ const factory = (MenuItem) => {
       active: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
-      hidden: PropTypes.bool,
       onHide: PropTypes.func,
       onSelect: PropTypes.func,
       onShow: PropTypes.func,
@@ -233,7 +232,7 @@ const factory = (MenuItem) => {
       }, this.props.className);
 
       return (
-        <div id={this.props.menuId} aria-hidden={this.props.hidden} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
+        <div id={this.props.menuId} aria-hidden={!this.props.active} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
           {this.props.outline ? <div className={theme.outline} style={outlineStyle} /> : null}
           <ul ref='menu' className={theme.menuInner} style={this.getMenuStyle()}>
             {this.renderItems()}

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -18,6 +18,7 @@ const POSITION = {
 const factory = (MenuItem) => {
   class Menu extends Component {
     static propTypes = {
+      menuId: PropTypes.string,
       autofocus: PropTypes.bool,
       active: PropTypes.bool,
       children: PropTypes.node,
@@ -231,7 +232,7 @@ const factory = (MenuItem) => {
       }, this.props.className);
 
       return (
-        <div data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
+        <div id={this.props.menuId} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
           {this.props.outline ? <div className={theme.outline} style={outlineStyle} /> : null}
           <ul ref='menu' className={theme.menuInner} style={this.getMenuStyle()}>
             {this.renderItems()}

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -18,6 +18,7 @@ const POSITION = {
 const factory = (MenuItem) => {
   class Menu extends Component {
     static propTypes = {
+      autofocus: PropTypes.bool,
       active: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
@@ -44,6 +45,7 @@ const factory = (MenuItem) => {
     };
 
     static defaultProps = {
+      autofocus: false,
       active: false,
       outline: true,
       position: POSITION.STATIC,
@@ -198,9 +200,22 @@ const factory = (MenuItem) => {
       });
     }
 
+    setFocus () {
+      const menuContainer = this.refs.menu.parentNode;
+      menuContainer.setAttribute('tabindex', -1);
+      menuContainer.focus();
+    }
+
     show () {
       const { width, height } = this.refs.menu.getBoundingClientRect();
+      let listenerTransition = () => {
+        this.setFocus();
+        this.refs.menu.removeEventListener(listenerTransition);
+      };
       this.setState({active: true, width, height});
+      if(this.props.autofocus) {
+        this.refs.menu.addEventListener('transitionend', listenerTransition);
+      }
     }
 
     hide () {

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -23,6 +23,7 @@ const factory = (MenuItem) => {
       active: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
+      hidden: PropTypes.bool,
       onHide: PropTypes.func,
       onSelect: PropTypes.func,
       onShow: PropTypes.func,
@@ -232,7 +233,7 @@ const factory = (MenuItem) => {
       }, this.props.className);
 
       return (
-        <div id={this.props.menuId} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
+        <div id={this.props.menuId} aria-hidden={this.props.hidden} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
           {this.props.outline ? <div className={theme.outline} style={outlineStyle} /> : null}
           <ul ref='menu' className={theme.menuInner} style={this.getMenuStyle()}>
             {this.renderItems()}

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -231,8 +231,18 @@ const factory = (MenuItem) => {
         [theme.rippled]: this.state.rippled
       }, this.props.className);
 
+      if(this.props.menuId) {
+        return (
+          <div id={this.props.menuId} aria-hidden={!this.props.active} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
+            {this.props.outline ? <div className={theme.outline} style={outlineStyle} /> : null}
+            <ul ref='menu' className={theme.menuInner} style={this.getMenuStyle()}>
+              {this.renderItems()}
+            </ul>
+          </div>
+        );
+      }
       return (
-        <div id={this.props.menuId} aria-hidden={!this.props.active} data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
+        <div data-react-toolbox='menu' className={className} style={this.getRootStyle()}>
           {this.props.outline ? <div className={theme.outline} style={outlineStyle} /> : null}
           <ul ref='menu' className={theme.menuInner} style={this.getMenuStyle()}>
             {this.renderItems()}

--- a/components/menu/readme.md
+++ b/components/menu/readme.md
@@ -28,7 +28,9 @@ This subcomponent is the default wrapper for a menu and is responsible for the o
 | Name          | Type          | Default     | Description|
 |:-----|:-----|:-----|:-----|
 | `active`      | `Boolean`     | `false`     | If true, the menu will be displayed as opened by default.|
+| `autofocus`      | `Boolean`     | `false`     | If true, the menu will be received the focus after is opened.|
 | `className`   | `String`      | `''`        | Set a class to give custom styles to the menu wrapper.|
+| `menuId`      | `String`     |      | Set an ID to establish the relation with a `IconButton` via `aria-controls` attribute.|
 | `onHide`      | `Function`    |             | Callback that will be called when the menu is being hidden. |
 | `onSelect`    | `Function`    |             | Callback that will be invoked when a menu item is selected. |
 | `onShow`      | `Function`    |             | Callback that will be invoked when the menu is being shown. |
@@ -64,8 +66,10 @@ As the most usual scenario will be to open the menu from a click in an Icon, we 
 | `className`     | `String`              |  `''`           | Set a class to give custom styles to the icon wrapper.|
 | `icon`          | `String` or `Element` | `more_vert`     | Icon font key string or Element to display the opener icon. |
 | `iconRipple`    | `Boolean`             | `true`          | If true, the icon will show a ripple when is clicked. |
+| `label`    | `String`             | `''`          | Set the `aria-label` attribute with the value of the property. |
 | `menuRipple`    | `Boolean`             | `true`          | Transferred to the `Menu` component. |
 | `onClick`       | `Function`            |                 | Callback that will be called when the icon is clicked. |
+| `onEscKeyDown`       | `Function`            |                 | Callback that will be called when the user press the Esc key. |
 | `onHide`        | `Function`            |                 | Callback that will be called when the menu is being hidden. |
 | `onSelect`      | `Function`            |                 | Callback that will be invoked when a menu item is selected. |
 | `onShow`        | `Function`            |                 | Callback that will be invoked when the menu is being shown. |

--- a/spec/components/icon_menu.js
+++ b/spec/components/icon_menu.js
@@ -29,6 +29,7 @@ class IconMenuTest extends React.Component {
         <h5>Icon Menus</h5>
         <p>Although a menu can be used indepently with any component, we are providing a common use case with the icon menu.</p>
         <IconMenu
+          label='show more options'
           icon='more_vert'
           position='auto'
           iconRipple

--- a/spec/components/icon_menu.js
+++ b/spec/components/icon_menu.js
@@ -34,6 +34,7 @@ class IconMenuTest extends React.Component {
           position='auto'
           iconRipple
           menuRipple
+          onEscKeyDown={this.handleHide}
           onShow={this.handleShow}
           onHide={this.handleHide}
           onSelect={this.handleSelect}


### PR DESCRIPTION
Hi, this pull request is related with #225. In that issue it says that it should be done from #666 but, because it has not been merged yet, I think that this pull request can be a good idea to take a look, at least, to the changes required to improve the accessibility of the `iconMenu` component. 

The accessibility improvements are:
+ add aria attributes to establish relationship between the icon and the menu, and also the visibility of the menu.
+ set the focus when the menu is opened. Important note: it is possible that the `MenuItem` component should be fixed too, because the elements inside it, are not `focusables`.. they are just `span` elements.
+ add support when the user press the escape key.

Regards.
