### PR TITLE
feat(a11y): alternative text for the FontIcon

### DIFF
--- a/components/font_icon/FontIcon.js
+++ b/components/font_icon/FontIcon.js
@@ -8,7 +8,6 @@ const FontIcon = ({ children, className, value, ...other}) => (
     {...other}
   >
     {value}
-    {children}
   </span>
 );
 

--- a/components/font_icon/FontIcon.js
+++ b/components/font_icon/FontIcon.js
@@ -1,17 +1,19 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
-const FontIcon = ({ children, className, value, ...other}) => (
+const FontIcon = ({ alt, children, className, value, ...other}) => (
   <span
     data-react-toolbox='font-icon'
+    aria-label={alt}
     className={classnames({'material-icons': typeof value === 'string' || typeof children === 'string'}, className)}
     {...other}
   >
-    {value}
+    <span aria-hidden="true">{value}</span>
   </span>
 );
 
 FontIcon.propTypes = {
+  alt: PropTypes.string,
   children: PropTypes.any,
   className: PropTypes.string,
   value: PropTypes.oneOfType([
@@ -21,6 +23,7 @@ FontIcon.propTypes = {
 };
 
 FontIcon.defaultProps = {
+  alt: '',
   className: ''
 };
 

--- a/components/font_icon/readme.md
+++ b/components/font_icon/readme.md
@@ -20,5 +20,6 @@ const FontIcons = () => (
 
 | Name            | Type                    | Default         | Description|
 |:-----|:-----|:-----|:-----|
+| `alt`     | `String`                | `''`            | The text used to set the `aria-label` attribute. 
 | `className`     | `String`                | `''`            | The class name to give custom styles such as sizing.|
 | `value`         | `String` or `Element`   |                 | The key string for the icon you want be displayed.|

--- a/components/font_icon/readme.md
+++ b/components/font_icon/readme.md
@@ -20,6 +20,5 @@ const FontIcons = () => (
 
 | Name            | Type                    | Default         | Description|
 |:-----|:-----|:-----|:-----|
-| `children`      | `String`                |                 | The key string for the icon you want to be displayed.|
 | `className`     | `String`                | `''`            | The class name to give custom styles such as sizing.|
 | `value`         | `String` or `Element`   |                 | The key string for the icon you want be displayed.|

--- a/spec/components/font_icon.js
+++ b/spec/components/font_icon.js
@@ -6,11 +6,11 @@ const FontIconTest = () => (
     <h5>Font Icons</h5>
     <p>lorem ipsum...</p>
 
-    <FontIcon value="add"/>
-    <FontIcon value="access_alarm"/>
-    <FontIcon value="explore"/>
-    <FontIcon value="zoom_in"/>
-    <FontIcon>input</FontIcon>
+    <FontIcon value="add" alt="add icon" />
+    <FontIcon value="access_alarm" />
+    <FontIcon value="explore" alt="explore icon" />
+    <FontIcon value="zoom_in" alt="zoom icon" />
+    <FontIcon alt="input icon">input</FontIcon>
   </section>
 );
 


### PR DESCRIPTION
- add attribute to set an alternative text to the icon.
- hide the text inside the component used by Material to render the icon.
- remove unused attribute `children`. This attribute had the same description as the `value` attribute in the README file.

It is related with #225.
