### PR TITLE
feat(a11y): improve accessibility for the SnackBar component

### DIFF
--- a/components/snackbar/Snackbar.js
+++ b/components/snackbar/Snackbar.js
@@ -19,6 +19,7 @@ const factory = (Overlay, Button) => {
       ]),
       onClick: PropTypes.func,
       onTimeout: PropTypes.func,
+      opener: PropTypes.object,
       theme: PropTypes.shape({
         accept: PropTypes.string,
         active: PropTypes.string,
@@ -39,13 +40,29 @@ const factory = (Overlay, Button) => {
     }
 
     componentWillReceiveProps (nextProps) {
+      const listenerTransition = () => {
+        this.setFocus();
+        this.refs.snackbar.removeEventListener('transitionend', listenerTransition);
+      };
+      if (nextProps.active) {
+        this.refs.snackbar.addEventListener('transitionend', listenerTransition);
+      }
       if (nextProps.active && nextProps.timeout) {
         this.scheduleTimeout(nextProps);
       }
     }
 
     componentWillUnmount () {
+      if (this.props.opener) {
+        this.props.opener.focus();
+      }
       clearTimeout(this.curTimeout);
+    }
+
+    setFocus () {
+      const container = this.refs.snackbar;
+      container.setAttribute('tabindex', -1);
+      container.focus();
     }
 
     scheduleTimeout = props => {
@@ -65,7 +82,7 @@ const factory = (Overlay, Button) => {
 
       return (
         <Overlay invisible>
-          <div data-react-toolbox='snackbar' className={className}>
+          <div data-react-toolbox='snackbar' ref='snackbar' className={className}>
             <span className={theme.label}>
               {label}
               {children}

--- a/components/snackbar/readme.md
+++ b/components/snackbar/readme.md
@@ -45,6 +45,7 @@ This component can be styled by context providing a theme with the key `RTSnackb
 | `label`       | `String or Element`     |               | Text to display in the content.|
 | `onClick`     | `Function`              |               | Callback function that will be called when the button action is clicked.|
 | `onTimeout`   | `Function`              |               | Callback function when finish the set timeout.|
+| `opener`        | `Object`                |               | Indicates the node which opens the component.|
 | `timeout`     | `Number`                |               | Amount of time in milliseconds after the Snackbar will be automatically hidden.|
 | `type`        | `String`                |               | Indicates the action type. Can be `accept`, `warning` or `cancel`|
 

--- a/components/snackbar/theme.scss
+++ b/components/snackbar/theme.scss
@@ -46,4 +46,7 @@
   margin-right: - $snackbar-horizontal-offset / 2;
   margin-bottom: - $snackbar-vertical-offset / 2;
   margin-left: $snackbar-button-offset;
+  &:focus {
+    outline: 1px solid $snackbar-color;
+  }
 }

--- a/spec/components/snackbar.js
+++ b/spec/components/snackbar.js
@@ -4,8 +4,8 @@ import Snackbar from '../../components/snackbar';
 
 class SnackbarTest extends React.Component {
   state = {
-    target: null,
-    active: false
+    active: false,
+    opener: null
   };
 
   handleSnackbarClick = () => {

--- a/spec/components/snackbar.js
+++ b/spec/components/snackbar.js
@@ -4,6 +4,7 @@ import Snackbar from '../../components/snackbar';
 
 class SnackbarTest extends React.Component {
   state = {
+    target: null,
     active: false
   };
 
@@ -15,8 +16,8 @@ class SnackbarTest extends React.Component {
     this.setState({active: false});
   };
 
-  handleClick = () => {
-    this.setState({active: true});
+  handleClick = (e) => {
+    this.setState({active: true, opener: e.target});
   };
 
   render () {
@@ -26,14 +27,15 @@ class SnackbarTest extends React.Component {
         <p>lorem ipsum...</p>
         <Button label='Show snackbar' primary raised onClick={this.handleClick} />
         <Snackbar
-          action='Hide'
+          action='Hide message'
           active={this.state.active}
-          timeout={2000}
           onClick={this.handleSnackbarClick}
           onTimeout={this.handleSnackbarTimeout}
+          opener={this.state.opener}
+          timeout={2000}
           type='warning'
         >
-          Snackbar action <strong>cancel</strong>
+          Snackbar message. <strong>This text will be bolded</strong>
         </Snackbar>
       </section>
     );


### PR DESCRIPTION
+ set the focus when the message is opened.
+ return the focus to the element which has opened the message.
+ show focus style when you focus over the button inside the message.

Related with #225.