### PR TITLE
Allow to change 'source' for single 'Autocomplete'

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -74,14 +74,6 @@ const factory = (Chip, Input) => {
      isValueAnObject: false
    };
 
-   componentWillReceiveProps (nextProps) {
-     if (!this.props.multiple) {
-       this.setState({
-         query: this.query(nextProps.value)
-       });
-     }
-   }
-
    shouldComponentUpdate (nextProps, nextState) {
      if (!this.state.focus && nextState.focus && this.props.direction === POSITION.AUTO) {
        const direction = this.calculateDirection();


### PR DESCRIPTION
It is now able to dynamically change source for single value
Autocomplete, for example in 'onInput' handler.

In case you change the `source` property for Autocomplete in `onQueryChange` handler:

```
queryChanged(value) {
  this.setState({employees: this.loadEmployees(value)});
}
```

for single value `Autocomplete`:

```
<Autocomplete
  multiple={false} label="Employee" name="employee" source={this.state.employees}
  value={this.state.employee} onInput={this.queryChanged.bind(this)}
/>
```

The value in `Input` component keeps empty or - in case you select value - cannot be changed.
