### PR TITLE
Fix error if list get null object

### DIFF
--- a/components/list/List.js
+++ b/components/list/List.js
@@ -30,7 +30,9 @@ const factory = (ListItem) => {
 
     renderItems () {
       return React.Children.map(this.props.children, (item) => {
-        if (item.type === ListItem) {
+        if (!item) {
+          return;
+        } else if (item.type === ListItem) {
           const selectable = mergeProp('selectable', item.props, this.props);
           const ripple = mergeProp('ripple', item.props, this.props);
           return React.cloneElement(item, { selectable, ripple });


### PR DESCRIPTION
Simple example:
render() { const a = null; return <List>{{a}}</List>; }

Get 'Uncaught TypeError: Cannot read property 'type' of null'