### PR TITLE
Typescript: Document Input methods

### DIFF
--- a/components/input/index.d.ts
+++ b/components/input/index.d.ts
@@ -136,6 +136,9 @@ export interface InputProps extends ReactToolbox.Props {
   value?: any;
 }
 
-export class Input extends React.Component<InputProps, {}> { }
+export class Input extends React.Component<InputProps, {}> {
+  public focus(): void
+  public blur(): void
+}
 
 export default Input;


### PR DESCRIPTION
As described in the docs:

blur used to blur the input element.
focus used to focus the input element.

http://react-toolbox.com/#/components/input