### PR TITLE
v1, Typescript typings fix Ripple index export.

### DIFF
--- a/components/ripple/index.js
+++ b/components/ripple/index.js
@@ -1,4 +1,5 @@
 import rippleFactory from './Ripple.js';
 import theme from './theme.scss';
 
-export default (options) => rippleFactory({ ...options, theme });
+export const Ripple = (options) => rippleFactory({ ...options, theme });
+export default Ripple;


### PR DESCRIPTION
[issue 1140](https://github.com/react-toolbox/react-toolbox/issues/1140).