### PR TITLE
Typescript: document  Input methods

### DIFF
--- a/components/input/Input.d.ts
+++ b/components/input/Input.d.ts
@@ -136,6 +136,16 @@ export interface InputProps extends ReactToolbox.Props {
   value?: any;
 }
 
-export class Input extends React.Component<InputProps, {}> { }
+export class Input extends React.Component<InputProps, {}> {
+  /**
+   * Used to focus the input element.
+   */
+  public focus(): void;
+
+  /**
+   * Used to blur the input element.
+   */
+  public blur(): void;
+}
 
 export default Input;


### PR DESCRIPTION
As described in the docs:

blur used to blur the input element.
focus used to focus the input element.

http://react-toolbox.com/#/components/input