### PR TITLE
Update Input with Icon to follow Material Spec.

### DIFF
--- a/components/input/_config.scss
+++ b/components/input/_config.scss
@@ -16,5 +16,6 @@ $input-underline-height:  2 * $unit !default;
 $input-icon-font-size: 2.4 * $unit !default;
 $input-icon-size: 2 * $input-icon-font-size !default;
 $input-icon-offset: 1.6 * $unit !default;
+$input-icon-right-space: 2 * $unit !default;
 $input-chevron-offset: .8 * $unit !default;
 $input-hint-opacity: 1 !default;

--- a/components/input/theme.scss
+++ b/components/input/theme.scss
@@ -7,14 +7,14 @@
   position: relative;
   padding: $input-padding 0;
   &.withIcon {
-    margin-left: $input-icon-size;
+    margin-left: $input-icon-size + $input-icon-right-space;
   }
 }
 
 .icon {
   position: absolute;
   top: $input-icon-offset;
-  left: -$input-icon-size;
+  left: -($input-icon-size + $input-icon-right-space);
   display: block;
   width: $input-icon-size;
   height: $input-icon-size;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5874330/22400458/3a699b74-e56a-11e6-956d-2958f173b672.png)

As you can see, the spec has a 20dp spacing between the icon, and the input. I added `$input-icon-right-space` to allow this to be customized and defaulted it to the 20dp in the spec.

![image](https://cloud.githubusercontent.com/assets/5874330/22400467/8f85f152-e56a-11e6-8241-d1407ce21dc7.png)


Link to the spec:
https://material.io/guidelines/components/text-fields.html#text-fields-single-line-text-field
