### PR TITLE
Move `react-style-proptype` to non-dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "gulp-rimraf": "^0.2.1",
     "ramda": "^0.23.0",
     "react-addons-css-transition-group": "^15.4.2",
-    "react-css-themr": "^1.7.2"
+    "react-css-themr": "^1.7.2",
+    "react-style-proptype": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",
@@ -91,7 +92,6 @@
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
-    "react-style-proptype": "^2.0.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.3.2",


### PR DESCRIPTION
Else there is an error:
```ERROR in ./~/react-toolbox/lib/checkbox/Checkbox.js
Module not found: Error: Can't resolve 'react-style-proptype' in '[stripped]\node_modules\react-toolbox\lib\checkbox'
 @ ./~/react-toolbox/lib/checkbox/Checkbox.js 38:26-57
 @ ./~/react-toolbox/lib/checkbox/index.js
 @ ./~/react-toolbox/lib/index.js
 @ [stripped]/index.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 webpack/hot/dev-server react-hot-loader/patch [stripped]/index.js

ERROR in ./~/react-toolbox/lib/checkbox/Check.js
Module not found: Error: Can't resolve 'react-style-proptype' in '[stripped]\node_modules\react-toolbox\lib\checkbox'
 @ ./~/react-toolbox/lib/checkbox/Check.js 15:26-57
 @ ./~/react-toolbox/lib/checkbox/index.js
 @ ./~/react-toolbox/lib/index.js
 @ [stripped]/index.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 webpack/hot/dev-server react-hot-loader/patch [stripped]/index.js

ERROR in ./~/react-toolbox/lib/slider/Slider.js
Module not found: Error: Can't resolve 'react-style-proptype' in [stripped]\node_modules\react-toolbox\lib\slider'
 @ ./~/react-toolbox/lib/slider/Slider.js 32:26-57
 @ ./~/react-toolbox/lib/slider/index.js
 @ ./~/react-toolbox/lib/index.js
 @ [stripped]/index.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 webpack/hot/dev-server react-hot-loader/patch [stripped]/index.js
```