### PR TITLE
Fixes #1086

### DIFF
--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -81,6 +81,7 @@ const factory = (Input) => {
     });
 
     open = (event) => {
+      if (this.state.active) return;
       const client = event.target.getBoundingClientRect();
       const screenHeight = window.innerHeight || document.documentElement.offsetHeight;
       const up = this.props.auto ? client.top > ((screenHeight / 2) + client.height) : false;


### PR DESCRIPTION
This PR fixes the issue described in #1086.

The bug results from `handleFocus()` attempting to call `open()` on a Dropdown instance that is already open. In most cases, this is a no-op, but some window size + page layout combinations cause a new value for `this.state.up` to be calculated, which results in the Dropdown items shifting on screen, and the subsequent click event not being dispatched to the intended Dropdown item.

This could alternatively be addressed by checking the `active` state inside of `handleFocus()`, but it seems to me that performing the check in `open()` will catch any similar corner cases where the Dropdown items would otherwise shift while already in an open state.