### PR TITLE
fix typo in app_bar readme.md

### DIFF
--- a/components/app_bar/readme.md
+++ b/components/app_bar/readme.md
@@ -6,7 +6,7 @@ The app bar is a special kind of toolbar that’s used for branding, navigation,
 ```jsx
 import AppBar from 'react-toolbox/lib/app_bar';
 import Navigation from 'react-toolbox/lib/navigation';
-import Link from 'react-toolbox/lib/Link';
+import Link from 'react-toolbox/lib/link';
 
 const GithubIcon = () => (
   <svg viewBox="0 0 284 277">


### PR DESCRIPTION
the example provided in the doc cause warning, its explained in this issue https://github.com/webpack/webpack/issues/2362, to avoid this issue import `import Link from 'react-toolbox/lib/link'` instead of `import Link from 'react-toolbox/lib/Link'`