### PR TITLE
Allow to reference Input via Autocomplete

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -415,6 +415,6 @@ const factory = (Chip, Input) => {
 };
 
 const Autocomplete = factory(InjectChip, InjectInput);
-export default themr(AUTOCOMPLETE)(Autocomplete);
+export default themr(AUTOCOMPLETE, null, { withRef: true })(Autocomplete);
 export { factory as autocompleteFactory };
 export { Autocomplete };

--- a/components/autocomplete/index.js
+++ b/components/autocomplete/index.js
@@ -6,7 +6,7 @@ import { Input } from '../input';
 import theme from './theme.css';
 
 const Autocomplete = autocompleteFactory(Chip, Input);
-const ThemedAutocomplete = themr(AUTOCOMPLETE, theme)(Autocomplete);
+const ThemedAutocomplete = themr(AUTOCOMPLETE, theme, { withRef: true })(Autocomplete);
 
 export default ThemedAutocomplete;
 export { ThemedAutocomplete as Autocomplete };


### PR DESCRIPTION
I have a use case where I've to call the `focus()` method of the `Input` component from `Autocomplete`. And I think others can have to same.

To be able to do it, `Autocomplete` should be referenceable in the `themr` wrapper.