### PR TITLE
Remove unnecessary reference to sliderLength in knobOffset method

### DIFF
--- a/components/slider/Slider.js
+++ b/components/slider/Slider.js
@@ -187,9 +187,8 @@ const factory = (ProgressBar, Input) => {
     }
 
     knobOffset() {
-      const { max, min } = this.props;
-      const translated = this.state.sliderLength * ((this.props.value - min) / (max - min));
-      return (translated * 100) / this.state.sliderLength;
+      const { max, min, value } = this.props;
+      return 100 * ((value - min) / (max - min));
     }
 
     move(position) {

--- a/components/slider/__tests__/index.spec.js
+++ b/components/slider/__tests__/index.spec.js
@@ -57,9 +57,8 @@ describe('Slider', () => {
   });
 
   describe('#knobOffset', () => {
-    it('returns the corresponding offset for a given value and slider length/start', () => {
+    it('returns percentage offset of knob for slider with given min/max/value props', () => {
       const slider = shallow(<Slider min={-500} max={500} value={-250} />).instance();
-      slider.setState({ sliderStart: 500, sliderLength: 100 });
       expect(slider.knobOffset()).toEqual(25);
     });
   });


### PR DESCRIPTION
The offset is currently multiplied then divided by sliderLength, and the test description is misleading.