### PR TITLE
Autocomplete accepting suggestionMatch none

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -40,7 +40,7 @@ const factory = (Chip, Input) => {
       showSelectedWhenNotInSource: PropTypes.bool,
       showSuggestionsWhenValueIsSet: PropTypes.bool,
       source: PropTypes.any,
-      suggestionMatch: PropTypes.oneOf(['disabled', 'start', 'anywhere', 'word']),
+      suggestionMatch: PropTypes.oneOf(['disabled', 'start', 'anywhere', 'word', 'none']),
       theme: PropTypes.shape({
         active: PropTypes.string,
         autocomplete: PropTypes.string,
@@ -254,6 +254,8 @@ const factory = (Chip, Input) => {
       } else if (suggestionMatch === 'word') {
         const re = new RegExp(`\\b${query}`, 'g');
         return re.test(value);
+      }else if(suggestionMatch === 'none'){
+        return value
       }
 
       return false;


### PR DESCRIPTION
I needed to use the autocomplete without the suggestion match, because i was filtering the results in my back end, so the Autocomplete don't need to filter nothing.

I create the value "none" to the option "suggestionMatch", where the autocomplete don't filter the words.