### PR TITLE
change label propTypes to allow element

### DIFF
--- a/components/button/BrowseButton.js
+++ b/components/button/BrowseButton.js
@@ -19,7 +19,10 @@ const factory = (ripple, FontIcon) => {
         PropTypes.element,
       ]),
       inverse: PropTypes.bool,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       mini: PropTypes.bool,
       neutral: PropTypes.bool,
       onChange: PropTypes.func,

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -20,7 +20,10 @@ const factory = (ripple, FontIcon) => {
         PropTypes.element,
       ]),
       inverse: PropTypes.bool,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       mini: PropTypes.bool,
       neutral: PropTypes.bool,
       onMouseLeave: PropTypes.func,

--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -16,7 +16,10 @@ const factory = (Input, DatePickerDialog) => {
     static propTypes = {
       active: PropTypes.bool,
       autoOk: PropTypes.bool,
-      cancelLabel: PropTypes.string,
+      cancelLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       className: PropTypes.string,
       disabledDates: React.PropTypes.arrayOf(PropTypes.instanceOf(Date)),
       enabledDates: React.PropTypes.arrayOf(PropTypes.instanceOf(Date)),
@@ -27,7 +30,10 @@ const factory = (Input, DatePickerDialog) => {
       ]),
       inputClassName: PropTypes.string,
       inputFormat: PropTypes.func,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       locale: React.PropTypes.oneOfType([
         React.PropTypes.string,
         React.PropTypes.object,
@@ -35,7 +41,10 @@ const factory = (Input, DatePickerDialog) => {
       maxDate: PropTypes.instanceOf(Date),
       minDate: PropTypes.instanceOf(Date),
       name: PropTypes.string,
-      okLabel: PropTypes.string,
+      okLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       onChange: PropTypes.func,
       onClick: PropTypes.func,
       onDismiss: PropTypes.func,

--- a/components/date_picker/DatePickerDialog.js
+++ b/components/date_picker/DatePickerDialog.js
@@ -7,7 +7,10 @@ const factory = (Dialog, Calendar) => {
     static propTypes = {
       active: PropTypes.bool,
       autoOk: PropTypes.bool,
-      cancelLabel: PropTypes.string,
+      cancelLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       className: PropTypes.string,
       disabledDates: React.PropTypes.arrayOf(PropTypes.instanceOf(Date)),
       enabledDates: React.PropTypes.arrayOf(PropTypes.instanceOf(Date)),
@@ -18,7 +21,10 @@ const factory = (Dialog, Calendar) => {
       maxDate: PropTypes.instanceOf(Date),
       minDate: PropTypes.instanceOf(Date),
       name: PropTypes.string,
-      okLabel: PropTypes.string,
+      okLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       onDismiss: PropTypes.func,
       onEscKeyDown: PropTypes.func,
       onOverlayClick: PropTypes.func,

--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -51,7 +51,10 @@ const factory = (Overlay, Button) => {
   Dialog.propTypes = {
     actions: PropTypes.arrayOf(PropTypes.shape({
       className: PropTypes.string,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       children: PropTypes.node,
     })),
     active: PropTypes.bool,

--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -15,7 +15,10 @@ const factory = (Input) => {
       className: PropTypes.string,
       disabled: PropTypes.bool,
       error: PropTypes.string,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       labelKey: PropTypes.string,
       name: PropTypes.string,
       onBlur: PropTypes.func,
@@ -35,7 +38,10 @@ const factory = (Input) => {
         error: PropTypes.string,
         errored: PropTypes.string,
         field: PropTypes.string,
-        label: PropTypes.string,
+        label: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element,
+        ]),
         required: PropTypes.string,
         selected: PropTypes.string,
         templateValue: PropTypes.string,

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -28,7 +28,10 @@ Link.propTypes = {
     PropTypes.string,
     PropTypes.element,
   ]),
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
+  ]),
   theme: PropTypes.shape({
     active: PropTypes.string,
     icon: PropTypes.string,

--- a/components/snackbar/Snackbar.js
+++ b/components/snackbar/Snackbar.js
@@ -24,7 +24,10 @@ const factory = (Button) => {
         active: PropTypes.string,
         button: PropTypes.string,
         cancel: PropTypes.string,
-        label: PropTypes.string,
+        label: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element,
+        ]),
         snackbar: PropTypes.string,
         warning: PropTypes.string,
       }),

--- a/components/switch/Switch.js
+++ b/components/switch/Switch.js
@@ -11,7 +11,10 @@ const factory = (Thumb) => {
       checked: PropTypes.bool,
       className: PropTypes.string,
       disabled: PropTypes.bool,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       name: PropTypes.string,
       onBlur: PropTypes.func,
       onChange: PropTypes.func,

--- a/components/tabs/Tab.js
+++ b/components/tabs/Tab.js
@@ -23,7 +23,10 @@ const factory = (ripple) => {
         active: PropTypes.string,
         disabled: PropTypes.string,
         hidden: PropTypes.string,
-        label: PropTypes.string,
+        label: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element,
+        ]),
         rippleWrapper: PropTypes.string,
         withIcon: PropTypes.string,
         withText: PropTypes.string,

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -12,14 +12,23 @@ const factory = (TimePickerDialog, Input) => {
   class TimePicker extends Component {
     static propTypes = {
       active: PropTypes.bool,
-      cancelLabel: PropTypes.string,
+      cancelLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       className: PropTypes.string,
       error: PropTypes.string,
       format: PropTypes.oneOf(['24hr', 'ampm']),
       inputClassName: PropTypes.string,
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       name: PropTypes.string,
-      okLabel: PropTypes.string,
+      okLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       onChange: PropTypes.func,
       onClick: PropTypes.func,
       onDismiss: PropTypes.func,

--- a/components/time_picker/TimePickerDialog.js
+++ b/components/time_picker/TimePickerDialog.js
@@ -7,11 +7,17 @@ const factory = (Dialog) => {
   class TimePickerDialog extends Component {
     static propTypes = {
       active: PropTypes.bool,
-      cancelLabel: PropTypes.string,
+      cancelLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       className: PropTypes.string,
       format: PropTypes.oneOf(['24hr', 'ampm']),
       name: PropTypes.string,
-      okLabel: PropTypes.string,
+      okLabel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+      ]),
       onDismiss: PropTypes.func,
       onEscKeyDown: PropTypes.func,
       onOverlayClick: PropTypes.func,


### PR DESCRIPTION
According to https://github.com/react-toolbox/react-toolbox/issues/1306 when using a React element for the label (because of translations for example) raises an invalid proptype error.

I changed all the label proptypes to allow both, string and element.