### PR TITLE
isValueAnObject() returns true when value is null

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -321,7 +321,7 @@ const factory = (Chip, Input) => {
     }
 
     isValueAnObject() {
-      return !Array.isArray(this.props.value) && typeof this.props.value === 'object';
+      return !Array.isArray(this.props.value) && typeof this.props.value === 'object' && this.props.value !== null;
     }
 
     mapToObject(map) {


### PR DESCRIPTION
Related to this issue: https://github.com/react-toolbox/react-toolbox/issues/1226

`isValueAnObject()` was returning `true` when `this.props.value` was `null` and it was messing up some conditionals and returning the incorrect value to set.

I wasn't able to reproduce the error related to not showing the list of options.