### PR TITLE
Fixes table clone element when child is null (#1272)

### DIFF
--- a/components/table/TableHead.js
+++ b/components/table/TableHead.js
@@ -47,10 +47,13 @@ const factory = (Checkbox, TableCell) => {
               onChange={this.handleSelect}
             />}
           </TableCell>}
-          {React.Children.map(children, (child, index) => cloneElement(child, {
-            column: index,
-            tagName: 'th',
-          }))}
+          {React.Children.map(children, (child, index) => {
+            if (!child) return null;
+            return cloneElement(child, {
+              column: index,
+              tagName: 'th',
+            });
+          })}
         </tr>
       );
     }

--- a/components/table/TableRow.js
+++ b/components/table/TableRow.js
@@ -36,10 +36,13 @@ const factory = (Checkbox, TableCell) => {
           {selectable && <TableCell className={theme.checkboxCell}>
             <Checkbox checked={selected} onChange={this.handleSelect} />
           </TableCell>}
-          {React.Children.map(children, (child, index) => cloneElement(child, {
-            column: index,
-            tagName: 'td',
-          }))}
+          {React.Children.map(children, (child, index) => {
+            if (!child) return null;
+            return cloneElement(child, {
+              column: index,
+              tagName: 'td',
+            });
+          })}
         </tr>
       );
     }


### PR DESCRIPTION
Fixes #1272. Not sure if `if (!child) return null;` is the best (or most beautiful) way to do it.