### PR TITLE
Fix Autocomplete direction calculation

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -80,16 +80,10 @@ const factory = (Chip, Input) => {
          query: this.query(nextProps.value)
        });
      }
-   }
-
-   shouldComponentUpdate (nextProps, nextState) {
-     if (!this.state.focus && nextState.focus && this.props.direction === POSITION.AUTO) {
-       const direction = this.calculateDirection();
-       if (this.state.direction !== direction) {
-         this.setState({ direction });
-       }
+     if (this.state.focus && this.props.direction !== nextProps.direction) {
+       const direction = this.calculateDirection(nextProps.direction);
+       this.setState({ direction });
      }
-     return true;
    }
 
    handleChange = (values, event) => {
@@ -122,7 +116,7 @@ const factory = (Chip, Input) => {
 
    handleQueryFocus = (event) => {
      this.suggestionsNode.scrollTop = 0;
-     this.setState({active: '', focus: true});
+     this.setState({active: '', focus: true, direction: this.calculateDirection(this.props.direction)});
      if (this.props.onFocus) this.props.onFocus(event);
    };
 
@@ -158,14 +152,14 @@ const factory = (Chip, Input) => {
      this.setState({active: event.target.id});
    };
 
-   calculateDirection () {
-     if (this.props.direction === 'auto') {
+   calculateDirection (propsDirection) {
+     if (propsDirection === 'auto') {
        const client = ReactDOM.findDOMNode(this.inputNode).getBoundingClientRect();
        const screen_height = window.innerHeight || document.documentElement.offsetHeight;
        const up = client.top > ((screen_height / 2) + client.height);
        return up ? 'up' : 'down';
      } else {
-       return this.props.direction;
+       return propsDirection;
      }
    }
 


### PR DESCRIPTION
Related issue: https://github.com/react-toolbox/react-toolbox/issues/649

The fix implemented in issue #649 did not appear to fix the behaviour of Autocomplete. Calling `setState` during `shouldComponentUpdate` doesn't result in the new state being set before render is called. This meant that the first render of the Autocomplete would have the previously calculated `direction` value, and this wouldn't be fixed until the next render.

This change moves the calculation of `state.direction` out of `shouldComponentUpdate` so that it is reliably updated prior to rendering after the Autocomplete gets focus.