### PR TITLE
Fix allowCreate in Autocomplete when value prop is an object

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -300,6 +300,10 @@ const factory = (Chip, Input) => {
           return obj;
         }, {});
 
+        if (Object.keys(newItem).length === 0 && newValue) {
+          newItem[newValue] = newValue;
+        }
+
         return this.handleChange(Object.assign(this.mapToObject(values), newItem), event);
       }
 


### PR DESCRIPTION
This change fixes the allowCreate functionality of Autocomplete component when the the value prop is an object. The autocomplete spec in dev branch already exhibits the bug: the array based autocomplete in the top adds new items just fine but same doesn't work with the object-based component below it even though both have the allowCreate prop set.

Related to comments in #755.