### PR TITLE
Fixes Ripple event error in case props.ripple === false

### DIFF
--- a/components/ripple/Ripple.js
+++ b/components/ripple/Ripple.js
@@ -222,9 +222,11 @@ const rippleFactory = (options = {}) => {
         };
       }
 
+      doRipple = () => (!this.props.disabled && this.props.ripple)
+
       handleMouseDown = (event) => {
         if (this.props.onMouseDown) this.props.onMouseDown(event);
-        if (!this.props.disabled) {
+        if (this.doRipple()) {
           const { x, y } = events.getMousePosition(event);
           this.animateRipple(x, y, false);
         }
@@ -232,7 +234,7 @@ const rippleFactory = (options = {}) => {
 
       handleTouchStart = (event) => {
         if (this.props.onTouchStart) this.props.onTouchStart(event);
-        if (!this.props.disabled) {
+        if (this.doRipple()) {
           const { x, y } = events.getTouchPosition(event);
           this.animateRipple(x, y, true);
         }


### PR DESCRIPTION
Ripple component tries to attach event handlers in case ripple is set to false; Causes e.g. ListItem component to fail for
`<ListItem ripple={false} />`