### PR TITLE
Esc key event listener leakage fixed

### DIFF
--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -24,7 +24,7 @@ class Overlay extends Component {
 
   componentDidMount() {
     const { active, lockScroll, onEscKeyDown } = this.props;
-    if (onEscKeyDown) document.body.addEventListener('keydown', this.handleEscKey.bind(this));
+    if (onEscKeyDown) document.body.addEventListener('keydown', this.handleEscKey);
     if (active && lockScroll) document.body.style.overflow = 'hidden';
   }
 
@@ -44,8 +44,12 @@ class Overlay extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.active && !prevProps.active && this.props.onEscKeyDown) {
-      document.body.addEventListener('keydown', this.handleEscKey.bind(this));
+    if (this.props.onEscKeyDown) {
+      if (this.props.active && !prevProps.active) {
+        document.body.addEventListener('keydown', this.handleEscKey);
+      } else if (!this.props.active && prevProps.active) {
+        document.body.removeEventListener('keydown', this.handleEscKey);
+      }
     }
   }
 


### PR DESCRIPTION
Overlay esc handler was leaking. It's arrow function, but .bind was used causing new instance to be created. This istance was never removed. Also proper handling for active/inactive in regard to registering esc handler was added.