### PR TITLE
add 'onActiveChange' callback to DatePicker

### DIFF
--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -36,6 +36,7 @@ const factory = (Input, DatePickerDialog) => {
       minDate: PropTypes.instanceOf(Date),
       name: PropTypes.string,
       okLabel: PropTypes.string,
+      onActiveChange: PropTypes.func,
       onChange: PropTypes.func,
       onClick: PropTypes.func,
       onDismiss: PropTypes.func,
@@ -70,8 +71,13 @@ const factory = (Input, DatePickerDialog) => {
       }
     }
 
+    toggleActive = (active) => {
+      if (this.props.onActiveChange) this.props.onActiveChange(active);
+      this.setState({ active });
+    };
+
     handleDismiss = () => {
-      this.setState({ active: false });
+      this.toggleActive(false);
       if (this.props.onDismiss) {
         this.props.onDismiss();
       }
@@ -79,31 +85,31 @@ const factory = (Input, DatePickerDialog) => {
 
     handleInputFocus = (event) => {
       events.pauseEvent(event);
-      this.setState({ active: true });
+      this.toggleActive(true);
     };
 
     handleInputBlur = (event) => {
       events.pauseEvent(event);
-      this.setState({ active: false });
+      this.toggleActive(false);
     };
 
     handleInputClick = (event) => {
       events.pauseEvent(event);
-      this.setState({ active: true });
+      this.toggleActive(true);
       if (this.props.onClick) this.props.onClick(event);
     };
 
     handleInputKeyPress = (event) => {
       if (event.charCode === 13) {
         events.pauseEvent(event);
-        this.setState({ active: true });
+        this.toggleActive(true);
       }
       if (this.props.onKeyPress) this.props.onKeyPress(event);
     };
 
     handleSelect = (value, event) => {
       if (this.props.onChange) this.props.onChange(value, event);
-      this.setState({ active: false });
+      this.toggleActive(true);
     };
 
     render() {

--- a/components/date_picker/readme.md
+++ b/components/date_picker/readme.md
@@ -46,7 +46,7 @@ If you want to provide a theme via context, the component key is `RTDatePicker`.
 
 | Name            | Type            | Default       | Description |
 |:-----|:-----|:-----|:-----|
-| `active`        | `Boolean`       | `false`       | Allows to control if the picker should be shown from outside. Beware you should update the prop when the Dialog is closed. |
+| `active`        | `Boolean`       | `false`       | Allows to control if the picker should be shown from outside. Use `onActiveChange` to update the prop when the Dialog is closed. |
 | `autoOk`        | `Boolean`       | `false`       | Automatically selects a date upon clicking on a day. |
 | `cancelLabel`   | `String`        | `'Cancel'`    | Label used for cancel button on date picker dialog. |
 | `className`     | `String`        |               | This class will be placed at the top of the `DatePickerDialog` component so you can provide custom styles.|
@@ -65,6 +65,7 @@ If you want to provide a theme via context, the component key is `RTDatePicker`.
 | `onEscKeyDown`  | `Function`      |               | Callback called when the ESC key is pressed with the overlay active. |
 | `onKeyPress`    | `Function`      |               | Callback invoked on Input key press.
 | `onOverlayClick`| `Function`      |               | Callback to be invoked when the dialog overlay is clicked.|
+| `onActiveChange`| `Function`      |               | Callback to be invoked when the active state is changed internally.  Use this if you are managing the `active` property yourself.|
 | `readonly`      | `Boolean`       |               | The input element will be readonly and look like disabled.|
 | `sundayFirstDayOfWeek` | `Boolean`| `false`       | Set week's first day to Sunday. Default week's first day is Monday ([ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Week_dates)). |
 | `value`         | `Date`          |               | Date object with the currently selected date. |


### PR DESCRIPTION
this makes external management of the 'active' property much simpler

for example - the onFocus event was cancelling the onClick event for the text box

the onFocus handler did not trigger the 'onClick' property and so there was no way to properly manage the 'active' property externally.

this commit adds a callback for whenever the 'active' state changes internally so the external state (e.g. in redux can be updated also)

the result should be:

 * whenever the internal state changes - the external callback triggers updating external state to the internal value
 * if the external state changes - the new value should be passed in as the 'active' property and this.componentWillReceiveProps will call this.setState

these changes should be backwards compatable with existing code as they don't change existing callback handlers or the internal triggers just adds an extra callback