### PR TITLE
Fix TableCell definition

### DIFF
--- a/components/table/TableCell.d.ts
+++ b/components/table/TableCell.d.ts
@@ -53,7 +53,7 @@ export interface TableCellProps extends ReactToolbox.Props {
   /**
    * If you provide a value the cell will show an arrow pointing down or up depending on the value to indicate it is a sorted element. Useful only for columns.
    */
-  sorted?: 'ASC' | 'DESC';
+  sorted?: 'asc' | 'desc';
   /**
    * The element tag, either `td` or `th`.
    * @default 'td'


### PR DESCRIPTION
As per source (https://github.com/react-toolbox/react-toolbox/blob/dev/components/table/TableCell.js#L7) `sorted` accepts lower-case strings but the TypeScript definition uses upper-case. So there is either error from TS (`TS2322:Type 'string' is not assignable to type '"ASC" | "DESC"'`) or React (`Warning: Failed prop type: Invalid prop `sorted` of value `ASC` supplied to `ThemedTableCell`, expected one of ["asc","desc"].`).