### PR TITLE
Allow and handle float index in tabs

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -80,19 +80,44 @@ const factory = (Tab, TabContent, FontIcon) => {
     };
 
     updatePointer = (idx) => {
-      if (this.navigationNode && this.navigationNode.children[idx]) {
-        requestAnimationFrame(() => {
-          const nav = this.navigationNode.getBoundingClientRect();
-          const label = this.navigationNode.children[idx].getBoundingClientRect();
-          const scrollLeft = this.navigationNode.scrollLeft;
-          this.setState({
-            pointer: {
-              top: `${nav.height}px`,
-              left: `${(label.left + scrollLeft) - nav.left}px`,
-              width: `${label.width}px`,
-            },
+      if (idx % 1 === 0) {
+        if (this.navigationNode && this.navigationNode.children[idx]) {
+          requestAnimationFrame(() => {
+            const nav = this.navigationNode.getBoundingClientRect();
+            const label = this.navigationNode.children[idx].getBoundingClientRect();
+            const scrollLeft = this.navigationNode.scrollLeft;
+            this.setState({
+              pointer: {
+                top: `${nav.height}px`,
+                left: `${(label.left + scrollLeft) - nav.left}px`,
+                width: `${label.width}px`,
+              },
+            });
           });
-        });
+        }
+      } else {
+        const leftIdx = Math.floor(idx);
+        const rightIdx = Math.ceil(idx);
+        if (
+          this.navigationNode
+          && this.navigationNode.children[leftIdx]
+          && this.navigationNode.children[rightIdx]
+        ) {
+          requestAnimationFrame(() => {
+            const nav = this.navigationNode.getBoundingClientRect();
+            const leftLabel = this.navigationNode.children[leftIdx].getBoundingClientRect();
+            const rightLabel = this.navigationNode.children[rightIdx].getBoundingClientRect();
+            const scrollLeft = this.navigationNode.scrollLeft;
+            const add = idx % 1;
+            this.setState({
+              pointer: {
+                top: `${nav.height}px`,
+                left: `${(((1 - add) * leftLabel.left) + (add * rightLabel.left) + scrollLeft) - nav.left}px`,
+                width: `${((1 - add) * leftLabel.width) + (add * rightLabel.width)}px`,
+              },
+            });
+          });
+        }
       }
     }
 

--- a/spec/components/tabs.js
+++ b/spec/components/tabs.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Tabs, Tab } from '../../components/tabs';
+import Slider from '../../components/slider'
 
 class TabsTest extends React.Component {
   state = {
     index: 1,
     fixedIndex: 1,
     inverseIndex: 1,
+    floatIndex: 1,
   };
 
   handleTabChange = (index) => {
@@ -20,6 +22,10 @@ class TabsTest extends React.Component {
     this.setState({ inverseIndex: index });
   };
 
+  handleFloatTabChange = (index) => {
+    this.setState({ floatIndex: index })
+  }
+
   handleActive = () => {
     console.log('Special one activated');
   };
@@ -29,7 +35,7 @@ class TabsTest extends React.Component {
       <section>
         <h5>Tabs</h5>
         <p>This tabs can be disabled or hidden</p>
-        <Tabs disableAnimatedBottomBorder index={this.state.index} onChange={this.handleTabChange}>
+        <Tabs disableAnimatedBottomBorder index={1} onChange={this.handleTabChange}>
           <Tab ripple={false} label="Primary"><small>Primary content (no ripple)</small></Tab>
           <Tab label="Secondary" onActive={this.handleActive}><small>Secondary content</small></Tab>
           <Tab label="Third" disabled><small>Disabled content</small></Tab>
@@ -65,6 +71,20 @@ class TabsTest extends React.Component {
           <Tab icon="favorite"><small>Second Content</small></Tab>
           <Tab icon="call"><small>Third Content</small></Tab>
         </Tabs>
+        <h5>Tabs with float index</h5>
+        <p>
+          If you pass an index value that is not an int, the pointer will render somewhere between the two nearest ints.
+          This could be useful for integration with libraries
+          like <a href="https://github.com/oliviertassinari/react-swipeable-views">react-swipeable-views</a>.
+        </p>
+        <Tabs index={this.state.floatIndex} onChange={this.handleFloatTabChange}>
+          <Tab label="First"><small>First Content</small></Tab>
+          <Tab label="Second"><small>Second Content</small></Tab>
+          <Tab label="Third"><small>Third Content</small></Tab>
+          <Tab label="Fourth"><small>Fourth Content</small></Tab>
+          <Tab label="Fifth"><small>Fifth Content</small></Tab>
+        </Tabs>
+        <Slider min={0} max={4} value={this.state.floatIndex} onChange={this.handleFloatTabChange} />
       </section>
     );
   }


### PR DESCRIPTION
This allows tabs to handle index values that are not ints. When the index is a float, the pointer will render somewhere between the tabs corresponding to the nearest index. This is useful for a better integration with libraries like [react-swipeable-views](https://github.com/oliviertassinari/react-swipeable-views).

You can look at the demo in the spec.

Here's a gif with it working with react-swipeable-views in an app I'm working on:
![react-toolbox and react-swipeable-views](https://thumbs.gfycat.com/FarawayFantasticIberianlynx-size_restricted.gif)