### PR TITLE
Add hover effect to raised buttons.

### DIFF
--- a/components/button/config.css
+++ b/components/button/config.css
@@ -2,23 +2,32 @@
   --button-border-radius: calc(0.2 * var(--unit));
   --button-height: calc(3.6 * var(--unit));
   --button-toggle-font-size: calc(2 * var(--unit));
+
   --button-primary-color: var(--color-primary);
   --button-primary-color-hover: color(var(--color-primary) a(20%));
   --button-primary-color-contrast: var(--color-primary-contrast);
-  --button-accent-color-contrast: var(--color-primary-contrast);
-  --button-accent-color-hover: color(var(--color-accent) a(20%));
+  --button-primary-color-contrast-hover: color(var(--color-primary-contrast) a(30%));
+
   --button-accent-color: var(--color-accent);
+  --button-accent-color-hover: color(var(--color-accent) a(20%));
+  --button-accent-color-contrast: var(--color-primary-contrast);
+  --button-accent-color-contrast-hover: color(var(--color-primary-contrast) a(30%));
+
   --button-neutral-color: var(--color-white);
-  --button-neutral-color-contrast: var(--palette-grey-900);
   --button-neutral-color-hover: color(var(--palette-grey-900) a(20%));
+  --button-neutral-color-contrast: var(--palette-grey-900);
+  --button-neutral-color-contrast-hover: color(var(--color-white) a(20%));
+
   --button-floating-font-size: calc(2.4 * var(--unit));
   --button-floating-height: calc(5.6 * var(--unit));
   --button-floating-mini-height: calc(4 * var(--unit));
   --button-floating-mini-font-size: calc(var(--button-floating-mini-height) / 2.25);
+
   --button-disabled-text-color: color(var(--color-black) a(26%));
   --button-disabled-background-color: color(var(--color-black) a(12%));
   --button-disabled-text-color-inverse: color(var(--color-black) a(54%));
   --button-disabled-background-inverse: color(var(--color-black) a(8%));
+
   --button-squared-icon-margin: calc(0.6 * var(--unit));
   --button-squared-min-width: calc(9 * var(--unit));
   --button-squared-padding: 0 calc(1.2 * var(--unit));

--- a/components/button/theme.css
+++ b/components/button/theme.css
@@ -112,6 +112,18 @@
   composes: button;
   composes: squared;
   composes: solid;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    border-radius: var(--button-border-radius);
+    background: transparent;
+    transition: background-color 0.2s var(--animation-curve-default);
+  }
 }
 
 .flat {
@@ -148,6 +160,18 @@
       line-height: var(--button-floating-mini-height);
     }
   }
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    border-radius: 50%;
+    background: transparent;
+    transition: background-color 0.2s var(--animation-curve-default);
+  }
 }
 
 .toggle {
@@ -174,6 +198,13 @@
   &.floating {
     background: var(--button-primary-color);
     color: var(--button-primary-color-contrast);
+
+    &:focus:not(:active),
+    &:hover {
+      &::after {
+        background: var(--button-primary-color-contrast-hover);
+      }
+    }
   }
 
   &.flat,
@@ -195,6 +226,13 @@
   &.floating {
     background: var(--button-accent-color);
     color: var(--button-accent-color-contrast);
+
+    &:focus:not(:active),
+    &:hover {
+      &::after {
+        background: var(--button-accent-color-contrast-hover);
+      }
+    }
   }
 
   &.flat,
@@ -216,6 +254,13 @@
   &.floating {
     background-color: var(--button-neutral-color);
     color: var(--button-neutral-color-contrast);
+
+    &:focus:not(:active),
+    &:hover {
+      &::after {
+        background: var(--button-neutral-color-hover);
+      }
+    }
   }
 
   &.flat,
@@ -236,6 +281,13 @@
     &.floating {
       background-color: var(--button-neutral-color-contrast);
       color: var(--button-neutral-color);
+
+      &:focus:not(:active),
+      &:hover {
+        &::after {
+          background: var(--button-neutral-color-contrast-hover);
+        }
+      }
     }
 
     &.flat,
@@ -248,7 +300,7 @@
     }
 
     &.flat:hover {
-      background: var(--button-neutral-color-hover);
+      background: var(--button-neutral-color-contrast-hover);
     }
   }
 }


### PR DESCRIPTION
Raised buttons have no hover effect like flat buttons do, and they should have said effect per the material design guidelines. I added this effect using an ::after pseudo-element whose background changes when the button is hovered.