### PR TITLE
Add support for treeshaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "http://www.react-toolbox.com",
   "version": "2.0.0-beta.8",
   "main": "./lib",
+  "module": "./components",
   "author": {
     "email": "javier.velasco86@gmail.com",
     "name": "Javier Velasco Arjona",


### PR DESCRIPTION
According to Rollup guide adding `module` field in package.json helps tree shaking aware tools like webpack 2 or rollup import the ES6 modules directly to use the tree shaking feature and reduce the bundle size.