### PR TITLE
Input component multiline does not auto resize if rows is defined

### DIFF
--- a/components/input/Input.d.ts
+++ b/components/input/Input.d.ts
@@ -54,6 +54,10 @@ export interface InputTheme {
 
 export interface InputProps extends ReactToolbox.Props {
   /**
+   * If true, a textarea height is adjusted to rows.
+   */
+   autoResize?: boolean,
+  /**
    * Children to pass through the component.
    */
   children?: React.ReactNode;

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -8,6 +8,7 @@ import InjectedFontIcon from '../font_icon/FontIcon';
 const factory = (FontIcon) => {
   class Input extends React.Component {
     static propTypes = {
+      autoResize: PropTypes.bool,
       children: PropTypes.node,
       className: PropTypes.string,
       defaultValue: PropTypes.string,
@@ -110,9 +111,9 @@ const factory = (FontIcon) => {
 
     handleAutoresize = () => {
       const element = this.inputNode;
-      const rows = this.props.rows;
+      const autoResize = this.props.autoResize;
 
-      if (typeof rows === 'number' && !isNaN(rows)) {
+      if (!autoResize) {
         element.style.height = null;
       } else {
         // compute the height difference between inner height and outer height
@@ -165,7 +166,7 @@ const factory = (FontIcon) => {
     )
 
     render() {
-      const { children, defaultValue, disabled, error, floating, hint, icon,
+      const { autoResize = true, children, defaultValue, disabled, error, floating, hint, icon,
               name, label: labelText, maxLength, multiline, required,
               theme, type, value, onKeyPress, rows = 1, ...others } = this.props;
       const length = maxLength && value ? value.length : 0;

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -62,6 +62,7 @@ const factory = (FontIcon) => {
     };
 
     static defaultProps = {
+      autoResize: true,
       className: '',
       hint: '',
       disabled: false,

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -203,6 +203,8 @@ const factory = (FontIcon) => {
         inputElementProps.onKeyPress = this.handleKeyPress;
       }
 
+      delete inputElementProps.autoResize;
+
       return (
         <div data-react-toolbox="input" className={className}>
           {React.createElement(multiline ? 'textarea' : 'input', inputElementProps)}

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -166,7 +166,7 @@ const factory = (FontIcon) => {
     )
 
     render() {
-      const { autoResize = true, children, defaultValue, disabled, error, floating, hint, icon,
+      const { children, defaultValue, disabled, error, floating, hint, icon,
               name, label: labelText, maxLength, multiline, required,
               theme, type, value, onKeyPress, rows = 1, ...others } = this.props;
       const length = maxLength && value ? value.length : 0;

--- a/components/input/readme.md
+++ b/components/input/readme.md
@@ -33,6 +33,7 @@ If you want to provide a theme via context, the component key is `RTInput`.
 
 | Name            | Type                    | Default         | Description|
 |:-----|:-----|:-----|:-----|
+| `autoResize`    | `Boolean`               | `true`          | If true, a textarea height is adjusted to rows.|
 | `className`     | `String`                | `''`            | Sets a class name to give custom styles.|
 | `disabled`      | `Boolean`               | `false`         | If true, component will be disabled.|
 | `error`         | `String` or `Node`      |                 | Give an error node to display under the field.|


### PR DESCRIPTION
**The problem**
If input component has property `rows` defined as number (PropType is number), the text area height is fixed to it and overflowing text will add scroll bar to it. If the property is defined as a string (e.g. "2"), the text area will auto-resize to lines. The problem with this is, that the prop type is defined as a number and the string value is not allowed there.

**Solution**
Add prop `autoResize` to manage auto-resizing. If its value is `true`, text area increase and decrease its height. Otherwise height is fixed. Default value is `true`