### PR TITLE
Migrate PropTypes

### DIFF
--- a/components/app_bar/AppBar.js
+++ b/components/app_bar/AppBar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { APP_BAR } from '../identifiers.js';

--- a/components/avatar/Avatar.js
+++ b/components/avatar/Avatar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { AVATAR } from '../identifiers.js';

--- a/components/card/Card.js
+++ b/components/card/Card.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardActions.js
+++ b/components/card/CardActions.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardMedia.js
+++ b/components/card/CardMedia.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardText.js
+++ b/components/card/CardText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardTitle.js
+++ b/components/card/CardTitle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { CARD } from '../identifiers.js';

--- a/components/checkbox/Check.js
+++ b/components/checkbox/Check.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const factory = (ripple) => {

--- a/components/chip/Chip.js
+++ b/components/chip/Chip.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { CHIP } from '../identifiers.js';

--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { DIALOG } from '../identifiers.js';

--- a/components/drawer/Drawer.js
+++ b/components/drawer/Drawer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { DRAWER } from '../identifiers.js';

--- a/components/font_icon/FontIcon.js
+++ b/components/font_icon/FontIcon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const FontIcon = ({ children, className, value, ...other}) => (

--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { LAYOUT } from '../identifiers.js';

--- a/components/layout/NavDrawer.js
+++ b/components/layout/NavDrawer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LAYOUT } from '../identifiers.js';

--- a/components/layout/Panel.js
+++ b/components/layout/Panel.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LAYOUT } from '../identifiers.js';

--- a/components/layout/Sidebar.js
+++ b/components/layout/Sidebar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LAYOUT } from '../identifiers.js';

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LINK } from '../identifiers.js';

--- a/components/list/ListCheckbox.js
+++ b/components/list/ListCheckbox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListDivider.js
+++ b/components/list/ListDivider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';
 

--- a/components/list/ListItemAction.js
+++ b/components/list/ListItemAction.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';
 

--- a/components/list/ListItemActions.js
+++ b/components/list/ListItemActions.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';
 import InjectListItemAction from './ListItemAction.js';

--- a/components/list/ListItemLayout.js
+++ b/components/list/ListItemLayout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListItemText.js
+++ b/components/list/ListItemText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListSubHeader.js
+++ b/components/list/ListSubHeader.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/menu/MenuDivider.js
+++ b/components/menu/MenuDivider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import { MENU } from '../identifiers.js';
 

--- a/components/navigation/Navigation.js
+++ b/components/navigation/Navigation.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { NAVIGATION } from '../identifiers.js';

--- a/components/radio/Radio.js
+++ b/components/radio/Radio.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const factory = (ripple) => {
   const Radio = ({checked, onMouseDown, theme, ...other}) => (

--- a/components/switch/Thumb.js
+++ b/components/switch/Thumb.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const factory = (ripple) => {
   const Thumb = ({onMouseDown, theme, ...other}) => (

--- a/components/table/TableHead.js
+++ b/components/table/TableHead.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const factory = (Checkbox) => {
   const TableHead = ({model, onSelect, selectable, multiSelectable, selected, theme}) => {

--- a/docs/app/components/layout/main/components/navigation.js
+++ b/docs/app/components/layout/main/components/navigation.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { List, ListItem } from 'react-toolbox';
 import classnames from 'classnames';
 import components from '../modules/components';

--- a/lib/button/IconButton.js
+++ b/lib/button/IconButton.js
@@ -96,7 +96,7 @@ var factory = function factory(ripple, FontIcon) {
           'data-react-toolbox': 'button'
         });
 
-        return _react2.default.createElement(element, props, icon ? _react2.default.createElement(FontIcon, { className: theme.icon, value: icon }) : null, children);
+        return _react2.default.createElement(element, props, icon ? typeof icon === 'string' ? _react2.default.createElement(FontIcon, { className: theme.icon, value: icon }) : icon : null, children);
       }
     }]);
 

--- a/lib/snackbar/Snackbar.js
+++ b/lib/snackbar/Snackbar.js
@@ -23,10 +23,6 @@ var _ActivableRenderer = require('../hoc/ActivableRenderer.js');
 
 var _ActivableRenderer2 = _interopRequireDefault(_ActivableRenderer);
 
-var _FontIcon = require('../font_icon/FontIcon.js');
-
-var _FontIcon2 = _interopRequireDefault(_FontIcon);
-
 var _Overlay = require('../overlay/Overlay.js');
 
 var _Overlay2 = _interopRequireDefault(_Overlay);
@@ -80,7 +76,6 @@ var factory = function factory(Overlay, Button) {
             action = _props.action,
             active = _props.active,
             children = _props.children,
-            icon = _props.icon,
             label = _props.label,
             onClick = _props.onClick,
             theme = _props.theme,
@@ -94,7 +89,6 @@ var factory = function factory(Overlay, Button) {
           _react2.default.createElement(
             'div',
             { 'data-react-toolbox': 'snackbar', className: className },
-            icon ? _react2.default.createElement(_FontIcon2.default, { value: icon, className: theme.icon }) : null,
             _react2.default.createElement(
               'span',
               { className: theme.label },
@@ -115,7 +109,6 @@ var factory = function factory(Overlay, Button) {
     active: _react.PropTypes.bool,
     children: _react.PropTypes.node,
     className: _react.PropTypes.string,
-    icon: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.element]),
     label: _react.PropTypes.oneOfType([_react.PropTypes.string, _react.PropTypes.element]),
     onClick: _react.PropTypes.func,
     onTimeout: _react.PropTypes.func,

--- a/lib/snackbar/index.d.ts
+++ b/lib/snackbar/index.d.ts
@@ -19,10 +19,6 @@ export interface SnackbarTheme {
    */
   cancel?: string;
   /**
-   * Used for the icon element.
-   */
-  icon?: string;
-  /**
    * Used for the label element.
    */
   label?: string;
@@ -46,10 +42,6 @@ interface SnackbarProps extends ReactToolbox.Props {
    * @default true
    */
   active?: boolean;
-  /**
-   * String key for an icon or Element which will be displayed in left side of the snackbar.
-   */
-  icon?: React.ReactNode | string;
   /**
    * Text to display in the content. Required.
    */

--- a/lib/snackbar/theme.scss
+++ b/lib/snackbar/theme.scss
@@ -35,10 +35,6 @@
   }
 }
 
-.icon {
-  margin-right: $snackbar-vertical-offset;
-}
-
 .label {
   flex-grow: 1;
   font-size: $font-size-small;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-toolbox",
   "description": "A set of React components implementing Google's Material Design specification with the power of CSS Modules.",
   "homepage": "http://www.react-toolbox.com",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "main": "./lib",
   "author": {
     "name": "React Toolbox Team",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-toolbox",
   "description": "A set of React components implementing Google's Material Design specification with the power of CSS Modules.",
   "homepage": "http://www.react-toolbox.com",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "./lib",
   "author": {
     "name": "React Toolbox Team",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "core-js": "~2.4.0",
     "immutability-helper": "^2.0.0",
     "normalize.css": "~4.2.0",
+    "prop-types": "^15.5.8",
     "react-css-themr": "~1.4.1"
   },
   "devDependencies": {

--- a/spec/components/dialog.js
+++ b/spec/components/dialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Button from '../../components/button';
 import Dialog from '../../components/dialog';
 import Dropdown from '../../components/dropdown';


### PR DESCRIPTION
React is deprecating PropTypes in the main package from v15.5. Use `prop-types` instead