### PR TITLE
Updated dependencies

### DIFF
--- a/components/date_picker/Calendar.js
+++ b/components/date_picker/Calendar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import CssTransitionGroup from 'react-addons-css-transition-group';
+import CssTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { range, getAnimationModule } from '../utils/utils';
 import time from '../utils/time';
 import CalendarMonth from './CalendarMonth';

--- a/components/time_picker/Clock.js
+++ b/components/time_picker/Clock.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import CssTransitionGroup from 'react-addons-css-transition-group';
+import CssTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { getAnimationModule } from '../utils/utils';
 import time from '../utils/time';
 import Hours from './ClockHours';

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,9 +13,9 @@
     "classnames": "^2.2.5",
     "codemirror": "^5.14.2",
     "history": "^2.1.1",
-    "react": "^15.2.0",
+    "react": "^15.5.0",
     "react-css-themr": "^1.2.0",
-    "react-dom": "^15.2.0",
+    "react-dom": "^15.5.0",
     "react-router": "^2.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "classnames": "^2.2.5",
     "core-js": "^2.4.0",
     "ramda": "^0.23.0",
-    "react-addons-css-transition-group": "^15.4.2",
     "react-css-themr": "^1.7.2",
-    "react-style-proptype": "^2.0.0"
+    "react-style-proptype": "^2.0.0",
+    "react-transition-group": "^1.1.3"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",
@@ -77,10 +77,10 @@
     "postcss-reporter": "^3.0.0",
     "pre-commit": "^1.2.2",
     "prop-types": "^15.5.7",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "react-test-renderer": "^15.4.2",
+    "react": "^15.5.0",
+    "react-addons-test-utils": "^15.5.0",
+    "react-dom": "^15.5.0",
+    "react-test-renderer": "^15.5.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "redbox-react": "^1.3.2",
@@ -135,9 +135,9 @@
   "peerDependencies": {
     "classnames": "^2.2.0",
     "prop-types": "^15.5.7",
-    "react": "^0.14 || ~15.4.0",
-    "react-addons-css-transition-group": "^0.14.0 || ~15.4.0",
-    "react-dom": "^0.14.0 || ~15.4.0"
+    "react": "^15.5.0",
+    "react-transition-group": "^1.1.3",
+    "react-dom": "^15.5.0"
   },
   "pre-commit": "lint:staged"
 }


### PR DESCRIPTION
Switched the react-addons-css-transition-group package (which is being deprecated) to react-transition-group/CSSTransitionGroup, and updated minimum React version to 15.5.0.