### PR TITLE
Breaking up dropdown

### DIFF
--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -8,6 +8,20 @@ import { DROPDOWN } from '../identifiers';
 import InjectInput from '../input/Input';
 import events from '../utils/events';
 
+function DropdownItem({ label, value, disabled, handleSelect, className  }) {
+  const onClick = (ev) => {
+    if (!disabled) handleSelect(value, ev);
+  }
+  return (
+    <li
+      className={className}
+      onClick={onClick}
+    >
+      {label}
+    </li>
+  );
+}
+
 const factory = (Input) => {
   class Dropdown extends Component {
     static propTypes = {
@@ -172,19 +186,20 @@ const factory = (Input) => {
     }
 
     renderValue = (item, idx) => {
-      const { labelKey, theme, valueKey } = this.props;
+      const { labelKey, theme, valueKey, template } = this.props;
       const className = classnames({
         [theme.selected]: item[valueKey] === this.props.value,
         [theme.disabled]: item.disabled,
       });
       return (
-        <li
+        <DropdownItem
           key={idx}
+          label={template ? template(item) : item[labelKey]}
+          value={item[valueKey]}
+          disabled={item.disabled}
           className={className}
-          onClick={!item.disabled && this.handleSelect.bind(this, item[valueKey])}
-        >
-          {this.props.template ? this.props.template(item) : item[labelKey]}
-        </li>
+          handleSelect={this.handleSelect}
+        />
       );
     };
 

--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -215,7 +215,7 @@ const factory = (Input) => {
             onClick={this.handleClick}
             required={this.props.required}
             readOnly
-            ref={(node) => { this.inputNode = node && node.getWrappedInstance(); }}
+            ref={(node) => { this.inputNode = node && node.inputNode; }}
             type={template && selected ? 'hidden' : null}
             theme={theme}
             themeNamespace="input"

--- a/components/dropdown/__test__/__snapshots__/index.spec.js.snap
+++ b/components/dropdown/__test__/__snapshots__/index.spec.js.snap
@@ -20,26 +20,27 @@ exports[`Dropdown snapshot testing Spain selected 1`] = `
     value="Spain" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className="selected"
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -66,26 +67,27 @@ exports[`Dropdown snapshot testing allowBlank=false 1`] = `
     value="England" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -112,26 +114,27 @@ exports[`Dropdown snapshot testing disabled 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -158,26 +161,27 @@ exports[`Dropdown snapshot testing none selected 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -204,26 +208,27 @@ exports[`Dropdown snapshot testing required=true 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -250,26 +255,27 @@ exports[`Dropdown snapshot testing with className 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -297,26 +303,27 @@ exports[`Dropdown snapshot testing with error message 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -344,26 +351,27 @@ exports[`Dropdown snapshot testing with label 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -390,26 +398,27 @@ exports[`Dropdown snapshot testing with minimum properties 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      England
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="England"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      Spain
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="Spain"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      Thailand
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="Thailand"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      USA
-    </li>
+      handleSelect={[Function]}
+      label="USA"
+      value="EN-en" />
   </ul>
 </div>
 `;
@@ -436,26 +445,27 @@ exports[`Dropdown snapshot testing with template 1`] = `
     value="" />
   <ul
     className="values">
-    <li
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      {\"value\":\"EN-gb\",\"label\":\"England\"}
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="{\"value\":\"EN-gb\",\"label\":\"England\"}"
+      value="EN-gb" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      {\"value\":\"ES-es\",\"label\":\"Spain\"}
-    </li>
-    <li
+      handleSelect={[Function]}
+      label="{\"value\":\"ES-es\",\"label\":\"Spain\"}"
+      value="ES-es" />
+    <DropdownItem
       className="disabled"
-      onClick={false}>
-      {\"value\":\"TH-th\",\"label\":\"Thailand\",\"disabled\":true}
-    </li>
-    <li
+      disabled={true}
+      handleSelect={[Function]}
+      label="{\"value\":\"TH-th\",\"label\":\"Thailand\",\"disabled\":true}"
+      value="TH-th" />
+    <DropdownItem
       className=""
-      onClick={[Function]}>
-      {\"value\":\"EN-en\",\"label\":\"USA\"}
-    </li>
+      handleSelect={[Function]}
+      label="{\"value\":\"EN-en\",\"label\":\"USA\"}"
+      value="EN-en" />
   </ul>
 </div>
 `;

--- a/components/dropdown/__test__/__snapshots__/index.spec.js.snap
+++ b/components/dropdown/__test__/__snapshots__/index.spec.js.snap
@@ -1,0 +1,451 @@
+exports[`Dropdown snapshot testing Spain selected 1`] = `
+<div
+  className="dropdown"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="Spain" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className="selected"
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing allowBlank=false 1`] = `
+<div
+  className="dropdown"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="England" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing disabled 1`] = `
+<div
+  className="dropdown disabled"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={true}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing none selected 1`] = `
+<div
+  className="dropdown"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing required=true 1`] = `
+<div
+  className="dropdown required"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={true}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing with className 1`] = `
+<div
+  className="dropdown something fancy"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing with error message 1`] = `
+<div
+  className="dropdown"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    error="some error message"
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing with label 1`] = `
+<div
+  className="dropdown"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    label="Select country"
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing with minimum properties 1`] = `
+<div
+  className="dropdown"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      England
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      Spain
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      Thailand
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      USA
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Dropdown snapshot testing with template 1`] = `
+<div
+  className="dropdown"
+  data-react-toolbox="dropdown"
+  onBlur={[Function]}
+  onFocus={[Function]}>
+  <Input
+    className="value"
+    disabled={false}
+    floating={true}
+    hint=""
+    multiline={false}
+    onClick={[Function]}
+    readOnly={true}
+    required={false}
+    tabIndex="0"
+    theme={Object {}}
+    type={null}
+    value="" />
+  <ul
+    className="values">
+    <li
+      className=""
+      onClick={[Function]}>
+      {\"value\":\"EN-gb\",\"label\":\"England\"}
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      {\"value\":\"ES-es\",\"label\":\"Spain\"}
+    </li>
+    <li
+      className="disabled"
+      onClick={false}>
+      {\"value\":\"TH-th\",\"label\":\"Thailand\",\"disabled\":true}
+    </li>
+    <li
+      className=""
+      onClick={[Function]}>
+      {\"value\":\"EN-en\",\"label\":\"USA\"}
+    </li>
+  </ul>
+</div>
+`;

--- a/components/dropdown/__test__/__snapshots__/index.spec.js.snap
+++ b/components/dropdown/__test__/__snapshots__/index.spec.js.snap
@@ -15,6 +15,7 @@ exports[`Dropdown snapshot testing Spain selected 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="Spain" />
   <ul
@@ -60,6 +61,7 @@ exports[`Dropdown snapshot testing allowBlank=false 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="England" />
   <ul
@@ -105,6 +107,7 @@ exports[`Dropdown snapshot testing disabled 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul
@@ -150,6 +153,7 @@ exports[`Dropdown snapshot testing none selected 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul
@@ -195,6 +199,7 @@ exports[`Dropdown snapshot testing required=true 1`] = `
     required={true}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul
@@ -240,6 +245,7 @@ exports[`Dropdown snapshot testing with className 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul
@@ -286,6 +292,7 @@ exports[`Dropdown snapshot testing with error message 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul
@@ -332,6 +339,7 @@ exports[`Dropdown snapshot testing with label 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul
@@ -377,6 +385,7 @@ exports[`Dropdown snapshot testing with minimum properties 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul
@@ -422,6 +431,7 @@ exports[`Dropdown snapshot testing with template 1`] = `
     required={false}
     tabIndex="0"
     theme={Object {}}
+    themeNamespace="input"
     type={null}
     value="" />
   <ul

--- a/components/dropdown/__test__/index.spec.js
+++ b/components/dropdown/__test__/index.spec.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import { Dropdown } from '../Dropdown';
+import theme from '../theme.css';
+
+const countries = [
+  { value: 'EN-gb', label: 'England' },
+  { value: 'ES-es', label: 'Spain' },
+  { value: 'TH-th', label: 'Thailand', disabled: true },
+  { value: 'EN-en', label: 'USA' },
+];
+
+describe('Dropdown', () => {
+  describe('snapshot testing', () => {
+    it('with no properties', () => {
+      expect(() => shallow(<Dropdown theme={theme} />)).toThrow();
+    });
+    it('with minimum properties', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('Spain selected', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} value="ES-es" />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('none selected', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} value="xxx" />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('allowBlank=false', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} allowBlank={false} value="xxx" />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('with className', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} className="something fancy" />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('disabled', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} disabled />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('with error message', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} error="some error message" />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('with label', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} label="Select country" />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('with template', () => {
+      const template = JSON.stringify;
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} template={template} />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+    it('required=true', () => {
+      const wrapper = shallow(<Dropdown theme={theme} source={countries} required />);
+      expect(toJson(wrapper)).toMatchSnapshot();
+    });
+  });
+  describe('Events testing', () => {
+    it('when clicked it should unfold the list', () => {
+      const wrapper = mount(<Dropdown theme={theme} source={countries} label="clicked" />);
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeFalsy();
+      wrapper.find('input.inputElement').simulate('click');
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeTruthy();
+    });
+    it('when item is clicked it should fire onChange event', () => {
+      const onChangeHandler = jest.fn();
+      const wrapper = mount(
+        <Dropdown
+          theme={theme}
+          source={countries}
+          onChange={onChangeHandler}
+          name="thisOne"
+        />);
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeFalsy();
+      wrapper.find('input.inputElement').simulate('click');
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeTruthy();
+      wrapper.find('ul.values').childAt(1).simulate('click');
+      expect(onChangeHandler).toHaveBeenCalled();
+      const [value, ev] = onChangeHandler.mock.calls[0];
+      expect(value).toEqual(countries[1].value);
+      expect(ev.target.name).toEqual('thisOne');
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeFalsy();
+    });
+    it('when disabled item is clicked it should do nothing', () => {
+      const onChangeHandler = jest.fn();
+      const wrapper = mount(
+        <Dropdown
+          theme={theme}
+          source={countries}
+          onChange={onChangeHandler}
+          name="thisOne"
+        />);
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeFalsy();
+      wrapper.find('input.inputElement').simulate('click');
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeTruthy();
+      wrapper.find('ul.values').childAt(2).simulate('click');
+      expect(wrapper.find('div.dropdown').hasClass('active')).toBeTruthy();
+      expect(onChangeHandler).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
The original purpose was to avoid dynamically binding the event handler to each list item, in order to reduce re-renders.  To make sure the change was good, I added a test-suite, which made me discover the user of a deprecated feature (`getWrappedInstance`), which I changed and then, finally the actual creation of `DropdownItem` which is a stateless component.