### PR TITLE
remove `theme[mode]` from progress_bar

### DIFF
--- a/components/progress_bar/ProgressBar.js
+++ b/components/progress_bar/ProgressBar.js
@@ -82,7 +82,6 @@ class ProgressBar extends Component {
   render() {
     const { className, disabled, max, min, mode, multicolor, type, theme, value } = this.props;
     const _className = classnames(theme[type], {
-      [theme[mode]]: mode,
       [theme.multicolor]: multicolor,
     }, className);
 


### PR DESCRIPTION
This is creating an error where `classnames` is trying to add a class value from `theme[mode]`. The issue is that there is no `mode` class in the `progress_bar/theme.css` and therefore, a class `undefined` is being added to the progress_bar. 

We love this library, but we're trying to remove all `undefined` classes from the components as we go. 
