### PR TITLE
Added label to InputTheme interface

### DIFF
--- a/components/input/Input.d.ts
+++ b/components/input/Input.d.ts
@@ -43,6 +43,10 @@ export interface InputTheme {
    */
   inputElement?: string;
   /**
+   * Used for the label when the input has a label.
+   */
+  label?: string;
+  /**
    * Used in case the input is required.
    */
   required?: string;


### PR DESCRIPTION
Addresses the error:

TS2322: Type '{ input: any; bar: any; label: any; inputElement: any; }' is not assignable to type 'InputTheme'.
      Object literal may only specify known properties, and 'label' does not exist in type 'InputTheme'.

when adding a theme for label in <Input theme={{label: styles.label}} />