### PR TITLE
Add a style props to Portal HOC

### DIFF
--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -7,6 +7,7 @@ class Portal extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     container: PropTypes.node,
+    style: PropTypes.style,
   }
 
   static defaultProps = {
@@ -55,7 +56,11 @@ class Portal extends Component {
 
   _getOverlay() {
     if (!this.props.children) return null;
-    return <div className={this.props.className}>{this.props.children}</div>;
+    return (
+      <div className={this.props.className} style={this.props.style}>
+        {this.props.children}
+      </div>
+    );
   }
 
   _renderOverlay() {


### PR DESCRIPTION
Allowing Portal to receives a style prop allow us to change the position portal on the fly on the screen. This is very useful when using a react-virtualize where one of the grid cells could include a portal. When you scroll, you want to the portal element move with the grid, this is not possible without passing the top/left position of the cell to the portal as a style props.

Example:
```jsx
class PortalMoves extends Component {
  constructor(props) {
    super(props);
    this.state = {
      top: 1,
      left: 1
    };
  }

  componentDidMount() {
    setInterval(() => {
      this.setState({
        top: this.state.top + 1,
        left: this.state.left + 1
      })
    }, 1000);
  }

  render() {
    return (
      <Portal style={this.state.style}>
        <div>move one around</div>
      </Portal>
    )
  }
}
```