### PR TITLE
Feature/tabs a11y

### DIFF
--- a/components/tabs/Tab.js
+++ b/components/tabs/Tab.js
@@ -65,7 +65,7 @@ const factory = (ripple) => {
       }, className);
 
       return (
-        <div {...other} data-react-toolbox="tab" className={_className} onClick={this.handleClick}>
+        <div {...other} data-react-toolbox="tab" role="tab" tabIndex="0" className={_className} onClick={this.handleClick}>
           {icon && <FontIcon className={theme.icon} value={icon} />}
           {label}
           {children}

--- a/components/tabs/TabContent.js
+++ b/components/tabs/TabContent.js
@@ -9,6 +9,7 @@ class TabContent extends Component {
     active: PropTypes.bool,
     children: PropTypes.node,
     className: PropTypes.string,
+    hidden: PropTypes.bool,
     tabIndex: PropTypes.number,
     theme: PropTypes.shape({
       active: PropTypes.string,
@@ -19,6 +20,7 @@ class TabContent extends Component {
   static defaultProps = {
     active: false,
     className: '',
+    hidden: true,
   };
 
   render() {
@@ -27,7 +29,7 @@ class TabContent extends Component {
     }, this.props.className);
 
     return (
-      <section className={className} tabIndex={this.props.tabIndex}>
+      <section className={className} role="tabpanel" aria-expanded={hidden} tabIndex={this.props.tabIndex}>
         {this.props.children}
       </section>
     );

--- a/components/tabs/TabContent.js
+++ b/components/tabs/TabContent.js
@@ -10,7 +10,6 @@ class TabContent extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     hidden: PropTypes.bool,
-    tabIndex: PropTypes.number,
     theme: PropTypes.shape({
       active: PropTypes.string,
       tab: PropTypes.string,
@@ -29,7 +28,7 @@ class TabContent extends Component {
     }, this.props.className);
 
     return (
-      <section className={className} role="tabpanel" aria-expanded={hidden}>
+      <section className={className} role="tabpanel" aria-expanded={this.props.hidden}>
         {this.props.children}
       </section>
     );

--- a/components/tabs/TabContent.js
+++ b/components/tabs/TabContent.js
@@ -29,7 +29,7 @@ class TabContent extends Component {
     }, this.props.className);
 
     return (
-      <section className={className} role="tabpanel" aria-expanded={hidden} tabIndex={this.props.tabIndex}>
+      <section className={className} role="tabpanel" aria-expanded={hidden}>
         {this.props.children}
       </section>
     );

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -197,10 +197,10 @@ const factory = (Tab, TabContent, FontIcon) => {
             {hasLeftArrow && <div className={theme.arrowContainer} onClick={this.scrollRight}>
               <FontIcon className={theme.arrow} value="keyboard_arrow_left" />
             </div>}
-            <nav className={theme.navigation} role='tablist' ref={(node) => { this.navigationNode = node; }}>
+            <div className={theme.navigation} role="tablist" ref={(node) => { this.navigationNode = node; }}>
               {this.renderHeaders(headers)}
               <span className={classNamePointer} style={this.state.pointer} />
-            </nav>
+            </div>
             {hasRightArrow && <div className={theme.arrowContainer} onClick={this.scrollLeft}>
               <FontIcon className={theme.arrow} value="keyboard_arrow_right" />
             </div>}

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -197,7 +197,7 @@ const factory = (Tab, TabContent, FontIcon) => {
             {hasLeftArrow && <div className={theme.arrowContainer} onClick={this.scrollRight}>
               <FontIcon className={theme.arrow} value="keyboard_arrow_left" />
             </div>}
-            <nav className={theme.navigation} ref={(node) => { this.navigationNode = node; }}>
+            <nav className={theme.navigation} role='tablist' ref={(node) => { this.navigationNode = node; }}>
               {this.renderHeaders(headers)}
               <span className={classNamePointer} style={this.state.pointer} />
             </nav>

--- a/components/tabs/config.css
+++ b/components/tabs/config.css
@@ -9,6 +9,7 @@
   --tab-navigation-border-color: var(--color-divider);
   --tab-pointer-color: var(--color-primary);
   --tab-pointer-height: calc(0.2 * var(--unit));
+  --tab-focus-color: color(var(--color-primary-contrast) a(10%));
   --tab-text: var(--color-black);
   --tab-text-color: var(--tab-text);
   --tab-text-inactive-color: color(var(--tab-text) a(70%));

--- a/components/tabs/theme.css
+++ b/components/tabs/theme.css
@@ -49,6 +49,11 @@
   transition-property: box-shadow, color;
   transition-timing-function: var(--animation-curve-default);
 
+  &:focus {
+    background-color: var(--tab-focus-color);
+    outline: none;
+  }
+
   & > .rippleWrapper {
     overflow: hidden;
   }

--- a/components/tabs/theme.css
+++ b/components/tabs/theme.css
@@ -46,7 +46,7 @@
   position: relative;
   text-transform: uppercase;
   transition-duration: var(--animation-duration);
-  transition-property: box-shadow, color;
+  transition-property: background-color, box-shadow, color;
   transition-timing-function: var(--animation-curve-default);
 
   &:focus {


### PR DESCRIPTION
Add a11y to tabs.

I did my best with the :focus style but I'm not picky as long as there is some tab navigation indicator.

In the future, `aria-controls` should also be configured, but this will be tricky if tab content is somewhere else on the page.