### PR TITLE
Do not show scrollbar on autocomplete component IE11

### DIFF
--- a/components/autocomplete/theme.css
+++ b/components/autocomplete/theme.css
@@ -14,6 +14,7 @@
       box-shadow: var(--zdepth-shadow-1);
       max-height: var(--autocomplete-overflow-max-height);
       visibility: visible;
+      -ms-overflow-style:none;
     }
   }
 }


### PR DESCRIPTION
Scrollbars are shown on the autocomplete component in IE11.

It is not possible to use the scrollbar after it appears which confuses my users.

I am not sure IE implementations are wanted, but this in any case disables the scrollbar so that the autocomplete looks more like in chrome.