### PR TITLE
Fix bug where dropdowns don't close

### DIFF
--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -130,7 +130,6 @@ const factory = (Input) => {
       const client = event.target.getBoundingClientRect();
       const screenHeight = window.innerHeight || document.documentElement.offsetHeight;
       const up = this.props.auto ? client.top > ((screenHeight / 2) + client.height) : false;
-      if (this.inputNode) this.inputNode.blur();
       this.setState({ active: true, up });
     };
 
@@ -207,6 +206,7 @@ const factory = (Input) => {
           data-react-toolbox="dropdown"
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
+          tabIndex="-1"
         >
           <Input
             {...others}
@@ -215,7 +215,6 @@ const factory = (Input) => {
             onClick={this.handleClick}
             required={this.props.required}
             readOnly
-            ref={(node) => { this.inputNode = node && node.getWrappedInstance(); }}
             type={template && selected ? 'hidden' : null}
             theme={theme}
             themeNamespace="input"


### PR DESCRIPTION
As I'm sure you're aware of, there are a few problems with the Dropdown component. To me, it seem to be mainly these two:

1. Dropdowns don't close when another is opened.
2. In some situations, the `onChange` event isn't fired when clicking on an item.

I know you've been working on a [new implementation](https://github.com/react-toolbox/react-toolbox/issues/1170), but I still feel like we should address these problems in the current implementation as well. I believe all these issues/PRs are related:

- https://github.com/react-toolbox/react-toolbox/issues/1354
- https://github.com/react-toolbox/react-toolbox/issues/1323
- https://github.com/react-toolbox/react-toolbox/pull/1521
- https://github.com/react-toolbox/react-toolbox/issues/1459
- https://github.com/react-toolbox/react-toolbox/issues/1246

[#1521](https://github.com/react-toolbox/react-toolbox/pull/1521) solves part of the problem by listening for `mousedown` rather than `click` on the dropdown items.  I don't really like this solution since it feels like a hack that could bite us further ahead (`click` and `mousedown`  really isn't the same). 

For the problem where dropdowns don't close, I believe it stems from [this line](https://github.com/react-toolbox/react-toolbox/blob/dev/components/dropdown/Dropdown.js#L133): 
`if (this.inputNode) this.inputNode.blur();`
Which is called whenever a dropdown is opened. I'm not exactly sure why it was added, but I can see it had something to do with [issues on iOS](https://github.com/react-toolbox/react-toolbox/issues/866). The reason it's problematic is that the component doesn't ever have "real" focus, and thus the `blur` event won't fire when another dropdown is opened. 

This PR tries to work around this by: 
1. Removing the parts which call `blur` programmatically on the input node.
2. Allow the dropdown to have focus by giving its container div `tabIndex="-1"`. This also eliminates the need for the hack in #1521.

It'd be great if others could try this as well, since I've only done some really basic testing myself (Chrome only). And I don't have access to a device running iOS, so I can't tell if this is messing things up over there. 