### PR TITLE
Fix compatibility with TypeScript@2.3.2

### DIFF
--- a/components/layout/Layout.d.ts
+++ b/components/layout/Layout.d.ts
@@ -52,10 +52,6 @@ export interface LayoutTheme {
 
 export interface LayoutProps extends ReactToolbox.Props {
   /**
-   * Children to pass through the component.
-   */
-  children?: [NavDrawer | Panel | Sidebar];
-  /**
    * Classnames object defining the component style.
    */
   theme?: LayoutTheme;


### PR DESCRIPTION
Embedding anything in <Layout> is not possible with TypeScript@2.3.2