### PR TITLE
This should fix bug in Tabs (react-toolbox@1.3.4 ) with incorrect pointer update

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -47,8 +47,12 @@ const factory = (Tab, TabContent, FontIcon) => {
       this.handleResize();
     }
 
-    componentWillReceiveProps (nextProps) {
-      this.updatePointer(nextProps.index);
+    componentDidUpdate (prevProps) {
+      const { index, children } = this.props;
+      const { index: prevIndex, children: prevChildren } = prevProps;
+      if (index !== prevIndex || children !== prevChildren) {
+        this.updatePointer(index);
+      }
     }
 
     componentWillUnmount () {


### PR DESCRIPTION
Hi! 
I use master branch (react-toolbox@1.3.4). The bug affects that version.
### Bug description.
When the `Tabs` component contains some `Tab` components that vary depending on an app state, pointer element (under active tab) could be rendered with incorrect width. 
_This doesn't affect initial render, only render after state changes that affect `Tab` components._
E.g. if an active tab receives a new `label` prop that has longer or shorter text than current `label` then `Tabs.updatePointer`  in `Tabs.componentWillReceiveProps` will calculate width at `nextProps.index` (which is correct), **but based on old tab element (which is incorrect)**.
the first state example: ![first-state](https://user-images.githubusercontent.com/12256600/27808721-7ddbbd02-6052-11e7-9ebf-ed4a94e4fa4d.jpg)
the second state example: ![second-state](https://user-images.githubusercontent.com/12256600/27808737-984fae0a-6052-11e7-9b4d-a1b753d9ac4e.jpg)
Notice how the blue pointer on the second example repeats the width of the pointer from the first example (previous tabs state).

### Suggested solution.
1. In `Tabs` component remove `componentWillReceiveProps` method.
2. In `Tabs` component add componentDidUpdate method as shown in the pull request.

### dev branch (2.x)
As I noticed, `componentDidUpdate` has been added like in my suggestion. That's nice but I think `componentWillReceiveProps` should be removed there. Though I cannot now test and prove for this version, it most probably triggers unnecessary  render for the old tabs and pointer that will be rerendered by state change in `componentDidUpdate` anyway.