### PR TITLE
Add workaround to isComponentOfType for react-hot-loader@^3

### DIFF
--- a/components/utils/is-component-of-type.js
+++ b/components/utils/is-component-of-type.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 let customChecker;
 
 /**
@@ -16,6 +18,10 @@ export function overrideComponentTypeChecker(providedChecker) {
  * @param reactElement {ReactElement} - any React Element (not a real DOM node)
  */
 export function defaultChecker(classType, reactElement) {
+  if (process.env.NODE_ENV !== 'production') {
+    // https://github.com/gaearon/react-hot-loader/blob/v3.0.0-beta.7/docs/Known%20Limitations.md#checking-element-types
+    classType = React.createElement(classType).type;// eslint-disable-line no-param-reassign
+  }
   return reactElement && reactElement.type === classType;
 }
 


### PR DESCRIPTION
As per discussions in https://github.com/react-toolbox/react-toolbox/issues/1443#issuecomment-312201476 #1148 and #1164, `react-hot-loader` also documents a [workaround][workaround]:

```js
const ComponentType = (<Component />).type;
const element = <Component />;
console.log(element.type === ComponentType); // true
```

Would you consider this version of `defaultChecker`?

[workaround]: https://github.com/gaearon/react-hot-loader/blob/master/docs/Known%20Limitations.md#checking-element-types