### PR TITLE
Widen typing for Layout children to 'any'

### DIFF
--- a/packages/react-toolbox/src/components/layout/Layout.d.ts
+++ b/packages/react-toolbox/src/components/layout/Layout.d.ts
@@ -53,8 +53,10 @@ export interface LayoutTheme {
 export interface LayoutProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
+   * 
+   * Ideally, this should be narrowed to only allow [NavDrawer | Panel | Sidebar]
    */
-  children?: [NavDrawer | Panel | Sidebar];
+  children?: any;
   /**
    * Classnames object defining the component style.
    */


### PR DESCRIPTION
Proposed fix for #1542 .  See https://github.com/Microsoft/TypeScript/issues/13618 for additional details as well, TS doesn't appear to have a good solve for this issue at this time.  For now, this change widens the requirement for `Layout` children to be an `any`.

It's not ideal, but does allow react-toolbox to be used with TS 2.3 and 2.4, where this did not work previously.

EDIT:  Targeting `agnostic-typescript`, as this appears to be the current branch npm releases are coming from, but I could be mistaken.  Let me know and I can re-target.