### PR TITLE
Fix compatibility with typescript 2.4+

### DIFF
--- a/packages/react-toolbox/src/components/drawer/Drawer.d.ts
+++ b/packages/react-toolbox/src/components/drawer/Drawer.d.ts
@@ -28,7 +28,7 @@ export interface DrawerTheme {
   wrapper?: string;
 }
 
-export interface DrawerProps extends ReactToolbox.Props {
+export interface DrawerCommonProps {
   /**
    * If true, the drawer will be visible.
    * @default false
@@ -48,10 +48,6 @@ export interface DrawerProps extends ReactToolbox.Props {
    */
   onOverlayClick?: Function;
   /**
-   * Classnames object defining the component style.
-   */
-  theme?: DrawerTheme;
-  /**
    * Type of drawer. It can be left or right to display the drawer on the left or right side of the screen.
    * @default left
    */
@@ -61,6 +57,13 @@ export interface DrawerProps extends ReactToolbox.Props {
    * @default true
    */
   withOverlay?: boolean;
+}
+
+export interface DrawerProps extends ReactToolbox.Props, DrawerCommonProps {
+  /**
+   * Classnames object defining the component style.
+   */
+  theme?: DrawerTheme;
 }
 
 export class Drawer extends React.Component<DrawerProps, {}> { }

--- a/packages/react-toolbox/src/components/layout/Layout.d.ts
+++ b/packages/react-toolbox/src/components/layout/Layout.d.ts
@@ -54,7 +54,7 @@ export interface LayoutProps extends ReactToolbox.Props {
   /**
    * Children to pass through the component.
    */
-  children?: [NavDrawer | Panel | Sidebar];
+  children?: JSX.Element | JSX.Element[];
   /**
    * Classnames object defining the component style.
    */

--- a/packages/react-toolbox/src/components/layout/Layout.d.ts
+++ b/packages/react-toolbox/src/components/layout/Layout.d.ts
@@ -1,8 +1,5 @@
 import * as React from "react";
 import ReactToolbox from "../index";
-import { NavDrawer } from './NavDrawer';
-import { Panel } from './Panel';
-import { Sidebar } from './Sidebar';
 
 export interface LayoutTheme {
   appbarFixed?: string;

--- a/packages/react-toolbox/src/components/layout/NavDrawer.d.ts
+++ b/packages/react-toolbox/src/components/layout/NavDrawer.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { DrawerProps } from '../drawer/Drawer';
+import {DrawerCommonProps} from '../drawer/Drawer';
 
 export interface NavDrawerTheme {
   /**
@@ -12,7 +12,7 @@ export interface NavDrawerTheme {
   clipped?: string;
 }
 
-export interface NavDrawerProps extends DrawerProps {
+export interface NavDrawerProps extends DrawerCommonProps {
   /**
    * If true, the drawer will be shown as an overlay.
    * @default false

--- a/packages/react-toolbox/src/components/layout/Sidebar.d.ts
+++ b/packages/react-toolbox/src/components/layout/Sidebar.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { DrawerProps } from '../drawer/Drawer';
+import {DrawerCommonProps} from '../drawer/Drawer';
 
 export interface SidebarTheme {
   /**
@@ -12,7 +12,7 @@ export interface SidebarTheme {
   pinned?: string;
 }
 
-export interface SidebarProps extends DrawerProps {
+export interface SidebarProps extends DrawerCommonProps {
   /**
    * If true, when the `AppBar` gets pinned, it will stand over the `Drawer`.
    * @default false


### PR DESCRIPTION
We cannot override interface properties on typescript, so, I added a interface to the Drawer component, named DrawerCommonProps with the common properties to share with other components (currently layout/Sidebar and layout/NavDrawer)

and some changes in the layout/Layout.d.ts, proposed by @Pajn in https://github.com/react-toolbox/react-toolbox/pull/1549#issuecomment-311597937 and as said in https://github.com/react-toolbox/react-toolbox/issues/1542#issuecomment-313010638 is just a workaround, when typescript resolve this problem we need to revert this change

address https://github.com/react-toolbox/react-toolbox/issues/1542
supersed https://github.com/react-toolbox/react-toolbox/pull/1549