### PR TITLE
Add default export TypeScript type to IconButton

### DIFF
--- a/components/button/IconButton.d.ts
+++ b/components/button/IconButton.d.ts
@@ -49,3 +49,5 @@ export interface IconButtonProps extends ButtonBaseProps {
 }
 
 export class IconButton extends React.Component<IconButtonProps, {}> { }
+
+export default IconButton


### PR DESCRIPTION
This is required when using IconButton with react-css-themr