### PR TITLE
solve #1444 and #1359.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ Declare plugins to be used by postcss (as part of webpack's config object):
   },
 ```
 
+Configure webpack 2.x or 3.x loader for .css files to use postcss:
+```js
+      {
+        test: /\.css$/,
+        use: [
+          "style-loader",
+          {
+            loader: "css-loader",
+            options: {
+              modules: true, // default is false
+              sourceMap: true,
+              importLoaders: 1,
+              localIdentName: "[name]--[local]--[hash:base64:8]"
+            }
+          },
+          "postcss-loader"
+        ]
+      }
+```
+
 ## Basic usage
 
 In this minimal example, we import a `Button` with styles already bundled:

--- a/components/drawer/config.css
+++ b/components/drawer/config.css
@@ -3,6 +3,6 @@
   --drawer-border-color: var(--palette-grey-300);
   --drawer-text-color: var(--palette-grey-800);
   --drawer-width: calc(24 * var(--unit));
-  --drawer-desktop-width: calc(4 * var(--standard-increment-desktop));
+  --drawer-desktop-width: calc(5 * var(--standard-increment-desktop));
   --drawer-mobile-width: calc(5 * var(--standard-increment-mobile));
 }


### PR DESCRIPTION
I use webpack version 2.6 and new configure syntax rather than 1.x.

When I follow the instruction on `readme.md`. It always failed on *Basic Usage* with the message below.
``` bash
ERROR in ./~/css-loader?{"modules":false,"importLoaders":1,"localIdentName":"[name]--[local]--[hash:base64:8]"}!./~/postcss-loader/lib!./~/react-toolbox/lib/button/theme.css
  Module build failed: Error: composition is only allowed when selector is single :local class name not in ".raised", ".raised" is weird
```
So I figured out what's wrong. The Default value of `css-loader` is false on new versions. 
It will solve #1444 and #1359. 