### PR TITLE
Replaced tab label with button element for keyboard accessibility. (v1.3.4)

### DIFF
--- a/components/tabs/Tab.js
+++ b/components/tabs/Tab.js
@@ -59,7 +59,7 @@ class Tab extends Component {
     }, className);
 
     return (
-      <button {...other} data-react-toolbox='tab' className={_className} onClick={this.handleClick}>
+      <button type="button" {...other} data-react-toolbox='tab' className={_className} onClick={this.handleClick}>
         {icon && <FontIcon className={theme.icon} value={icon}/>}
         {label}
       </button>

--- a/components/tabs/Tab.js
+++ b/components/tabs/Tab.js
@@ -59,10 +59,10 @@ class Tab extends Component {
     }, className);
 
     return (
-      <label {...other} data-react-toolbox='tab' className={_className} onClick={this.handleClick}>
+      <button {...other} data-react-toolbox='tab' className={_className} onClick={this.handleClick}>
         {icon && <FontIcon className={theme.icon} value={icon}/>}
         {label}
-      </label>
+      </button>
     );
   }
 }

--- a/components/tabs/theme.scss
+++ b/components/tabs/theme.scss
@@ -38,12 +38,15 @@
 
 .label {
   padding: $tab-label-v-padding $tab-label-h-padding;
+  font-family: inherit;
   font-size: $tab-text-height;
   font-weight: $font-weight-semi-bold;
   line-height: 1;
   color: $tab-text-inactive-color;
   text-align: center;
   text-transform: uppercase;
+  background: none;
+  border: 0;
   transition-timing-function: $animation-curve-default;
   transition-duration: $animation-duration;
   transition-property: box-shadow, color;


### PR DESCRIPTION
Using an actual button element for the tab labels makes them selectable by keyboard, and is more semantically correct (a11y!).