### PR TITLE
Make checkbox border color according to spec

### DIFF
--- a/components/checkbox/config.css
+++ b/components/checkbox/config.css
@@ -8,6 +8,7 @@
   --checkbox-focus-color: color(var(--color-black) a(1%));
   --checkbox-focus-size: calc(var(--checkbox-size) * 2.3);
   --checkbox-text-color: var(--color-black);
+  --checkbox-border-color: var(--palette-grey-600);
   --checkbox-text-font-size: var(--font-size-small);
   --checkbox-total-height: calc(1.8 * var(--unit));
   --checkbox-transition-duration: 0.2s;

--- a/components/checkbox/theme.css
+++ b/components/checkbox/theme.css
@@ -57,7 +57,7 @@
 }
 
 .check {
-  border-color: var(--checkbox-text-color);
+  border-color: var(--checkbox-border-color);
   border-radius: 2px;
   border-style: solid;
   border-width: 2px;


### PR DESCRIPTION
Checkboxes should be gray as seen in examples in material design guides:
https://material.io/guidelines/components/data-tables.html
https://material.io/guidelines/components/lists.html

Else it's too heavy on the screen (currently it is black in react-toolbox).

<img src="https://user-images.githubusercontent.com/534510/29117495-a7aba548-7cfe-11e7-94fd-5cb4ba661e11.png" alt="" width="200">
