### PR TITLE
Disabled input should be dashed not dotted

### DIFF
--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -158,7 +158,7 @@
 }
 
 .disabled > .inputElement {
-  border-bottom-style: dotted;
+  border-bottom-style: dashed;
   color: var(--input-text-disabled-text-color);
 }
 


### PR DESCRIPTION
According to spec example 
https://material.io/guidelines/components/text-fields.html#text-fields-states

![2017-08-09 12_56_19-text fields - components - material design guidelines](https://user-images.githubusercontent.com/534510/29118421-2ccbcd68-7d02-11e7-9920-fc2feaa88f9c.png)
