### PR TITLE
Add AppBar icon more spacing

### DIFF
--- a/components/app_bar/theme.css
+++ b/components/app_bar/theme.css
@@ -63,6 +63,7 @@
 
 .leftIcon {
   margin-left: calc(-1.2 * var(--unit));
+  margin-right: calc(1.2 * var(--unit));
 }
 
 .rightIcon {


### PR DESCRIPTION
I've seen Menu title have same space to left corner as Menu labels in examples. https://material.io/guidelines/components/lists.html

I tried to add a `Menu` to `NavDrawer` and to align `AppBar`'s title text with Menu labels. This PR makes it look as this (vertical line is to make it clear what is aligned):
![app-bar](https://user-images.githubusercontent.com/534510/29124920-9366cab0-7d1a-11e7-81d0-8dfcb944445f.jpg)
