### PR TITLE
Make list divider conform material design spec

### DIFF
--- a/components/app_bar/theme.css
+++ b/components/app_bar/theme.css
@@ -63,7 +63,6 @@
 
 .leftIcon {
   margin-left: calc(-1.2 * var(--unit));
-  margin-right: calc(1.2 * var(--unit));
 }
 
 .rightIcon {

--- a/components/app_bar/theme.css
+++ b/components/app_bar/theme.css
@@ -63,6 +63,7 @@
 
 .leftIcon {
   margin-left: calc(-1.2 * var(--unit));
+  margin-right: calc(1.2 * var(--unit));
 }
 
 .rightIcon {

--- a/components/list/ListDivider.js
+++ b/components/list/ListDivider.js
@@ -3,20 +3,24 @@ import PropTypes from 'prop-types';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers';
 
-const ListDivider = ({ inset, theme }) => (
-  <hr className={inset ? `${theme.divider} ${theme.inset}` : theme.divider} />
+const ListDivider = ({ inset, thick, className, theme }) => (
+  <hr className={`${inset && theme.inset} ${thick && theme.thick} ${theme.divider} ${className && className}`} />
 );
 
 ListDivider.propTypes = {
+  className: PropTypes.string,
   inset: PropTypes.bool,
   theme: PropTypes.shape({
     divider: PropTypes.string,
     inset: PropTypes.string,
+    thick: PropTypes.string,
   }),
+  thick: PropTypes.bool,
 };
 
 ListDivider.defaultProps = {
   inset: false,
+  className: false,
 };
 
 export default themr(LIST)(ListDivider);

--- a/components/list/theme.css
+++ b/components/list/theme.css
@@ -13,10 +13,6 @@
   width: 100%;
 
   @apply --reset;
-
-  & + .divider {
-    margin-top: calc(-1 * var(--list-vertical-padding));
-  }
 }
 
 .subheader {
@@ -32,11 +28,19 @@
   background-color: var(--color-divider);
   border: 0;
   height: var(--list-divider-height);
-  margin: calc(-1 * var(--list-divider-height)) 0 0;
+  margin: 0;
 
   &.inset {
     margin-left: var(--list-content-left-spacing);
-    margin-right: var(--list-horizontal-padding);
+  }
+
+  &.thick {
+    margin-bottom: var(--list-vertical-padding);
+    margin-top: var(--list-vertical-padding);
+  }
+
+  &:last-child {
+    display: none;
   }
 }
 
@@ -52,6 +56,10 @@
   }
 
   & ~ .divider {
+    margin-top: calc(-1 * var(--list-divider-height));
+  }
+
+  & ~ .divider.thick {
     margin-bottom: var(--list-vertical-padding);
     margin-top: var(--list-vertical-padding);
   }

--- a/spec/components/list.js
+++ b/spec/components/list.js
@@ -49,24 +49,28 @@ class ListTest extends React.Component {
               legend="Product Manager at Fon"
               rightIcon="star"
             />
+            <ListDivider inset />
             <ListItem
               avatar="https://pbs.twimg.com/profile_images/693578804808278017/a5y4h8MN_400x400.png"
               caption="Javi Velasco"
               legend="Frontend engineer at Audiense"
               rightIcon="star"
             />
+            <ListDivider inset thick />
             <ListItem
               avatar="https://avatars2.githubusercontent.com/u/559654?v=3&s=460"
               caption="Javi Jiménez"
               legend="Frontend engineer at MediaSmart"
               rightIcon="star"
             />
+            <ListDivider inset />
             <ListItem
               avatar="https://pbs.twimg.com/profile_images/755797598565531649/Whsf9259.jpg"
               caption="Tobias Van Schneider"
               legend="Designer at Spotify"
               rightIcon="star"
             />
+            <ListDivider inset />
           </List>
         </div>
 


### PR DESCRIPTION
According to https://material.io/guidelines/components/dividers.html

dividers by default should have no spacing
> Dividers are placed along the bottom edge of the content tiles, independent of the grid.

![2017-08-10 15_40_00-dividers - components - material design guidelines](https://user-images.githubusercontent.com/534510/29173038-3aec355a-7de2-11e7-8010-ce8a8d74504b.png)

* Removed empty space by default
* Added possibility to get old "spacy" behaviour with `thick` prop
* According to spec `inset` divider should have no right margin/padding (removed)
* Make divider which is last child in list invisible (useful when rendering lists to not to worry of not rendering last divider)

Later I suggest such changes to follow:
* Make divider separate from lists. According to spec it's a separate standalone element. Can be reused in Menus.
* Use Lists for rendering menus (to prevent copy-paste)
* Allow list items to be links (if `href` prop is there - make wrapper an `a` element instead of `span`)

