### PR TITLE
Add helper text to input

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -17,6 +17,10 @@ const factory = (FontIcon) => {
         PropTypes.node,
       ]),
       floating: PropTypes.bool,
+      helper: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node,
+      ]),
       hint: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.node,
@@ -45,6 +49,7 @@ const factory = (FontIcon) => {
         disabled: PropTypes.string,
         error: PropTypes.string,
         errored: PropTypes.string,
+        helper: PropTypes.string,
         hidden: PropTypes.string,
         hint: PropTypes.string,
         icon: PropTypes.string,
@@ -63,6 +68,7 @@ const factory = (FontIcon) => {
 
     static defaultProps = {
       className: '',
+      helper: '',
       hint: '',
       disabled: false,
       floating: true,
@@ -167,7 +173,7 @@ const factory = (FontIcon) => {
     )
 
     render() {
-      const { children, defaultValue, disabled, error, floating, hint, icon,
+      const { children, defaultValue, disabled, error, floating, helper, hint, icon,
               name, label: labelText, maxLength, multiline, required, role,
               theme, type, value, onKeyPress, rows = 1, ...others } = this.props;
       const length = maxLength && value ? value.length : 0;
@@ -216,6 +222,7 @@ const factory = (FontIcon) => {
             : null}
           {hint ? <span hidden={labelText} className={theme.hint}>{hint}</span> : null}
           {error ? <span className={theme.error}>{error}</span> : null}
+          {helper ? <span className={theme.helper}>{helper}</span> : null}
           {maxLength ? <span className={theme.counter}>{length}/{maxLength}</span> : null}
           {children}
         </div>

--- a/components/input/config.css
+++ b/components/input/config.css
@@ -12,6 +12,7 @@
   --input-text-disabled-color: var(--input-text-bottom-border-color);
   --input-text-disabled-text-color: var(--input-text-label-color);
   --input-text-error-color: rgb(222, 50, 38);
+  --input-text-helper-color: color(var(--color-black) a(26%));
   --input-text-required-color: rgb(222, 50, 38);
   --input-underline-height: calc(2 * var(--unit));
   --input-icon-font-size: calc(2.4 * var(--unit));

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -144,11 +144,16 @@
 }
 
 .error,
+.helper,
 .counter {
   color: var(--input-text-error-color);
   font-size: var(--input-label-font-size);
   line-height: var(--input-underline-height);
   margin-bottom: calc(-1 * var(--input-underline-height));
+}
+
+.helper {
+  color: var(--input-text-helper-color);
 }
 
 .counter {

--- a/spec/components/input.js
+++ b/spec/components/input.js
@@ -8,6 +8,7 @@ class InputTest extends React.Component {
     withIcon: '',
     withCustomIcon: '',
     withHintCustomIcon: '',
+    withHelperText: '',
     multilineHint: 'Long Description here',
     multilineRows: 'A\n\B\nC\nD\nE\nF',
   };
@@ -36,6 +37,8 @@ class InputTest extends React.Component {
         <Input type="tel" name="withIcon" value={this.state.withIcon} required label="With icon" onChange={this.handleChange} icon="phone" />
         <Input type="tel" name="withCustomIcon" value={this.state.withCustomIcon} label="With custom icon" onChange={this.handleChange} icon="favorite" />
         <Input type="text" name="withHintCustomIcon" value={this.state.withHintCustomIcon} label="With Hint Text Icon" hint="Hint Text" onChange={this.handleChange} icon="share" />
+        <Input type="text" name="withHelperText" value={this.state.withHelperText} label="With Helper Text" helper="Some Helper Text" onChange={this.handleChange} icon="home" />
+        <Input type="text" name="withErrorText" value={this.state.withHelperText} label="With Error" error="Some Error" onChange={this.handleChange} icon="error" />
       </section>
     );
   }


### PR DESCRIPTION
Add ability to insert Helper text
https://material.io/guidelines/components/text-fields.html#text-fields-layout

![image](https://user-images.githubusercontent.com/534510/29307739-5376d264-81a3-11e7-82fb-1fb53aef3967.png)
