### PR TITLE
Portal: Fix Invalid "style" PropType

### DIFF
--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -1,13 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
+import styleShape from 'react-style-proptype';
 
 class Portal extends Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     container: PropTypes.node,
-    style: PropTypes.string,
+    style: styleShape,
   }
 
   static defaultProps = {

--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -7,7 +7,7 @@ class Portal extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     container: PropTypes.node,
-    style: PropTypes.style,
+    style: PropTypes.string,
   }
 
   static defaultProps = {


### PR DESCRIPTION
`PropTypes.style` is invalid. In certain cases - seeing this warning in a dev environment.

```
Warning: Failed prop type: Portal: prop type `style` is invalid; it must be a function, usually from React.PropTypes.
    in Portal
```