### PR TITLE
Fix Failing CI Jobs / lint:css

### DIFF
--- a/components/autocomplete/theme.css
+++ b/components/autocomplete/theme.css
@@ -13,8 +13,8 @@
     & .suggestions {
       box-shadow: var(--zdepth-shadow-1);
       max-height: var(--autocomplete-overflow-max-height);
+      -ms-overflow-style: none;
       visibility: visible;
-      -ms-overflow-style:none;
     }
   }
 }


### PR DESCRIPTION
This fixes `lint:css` errors. Below is the output currently when running `npm run lint:css`:

```
components/autocomplete/theme.css
 17:7   ✖  Expected -ms-overflow-style to   order/properties-alphabetical-order
           come before visibility                                              
 17:26  ✖  Expected single space after ":"  declaration-colon-space-after      
           with a single-line declaration
```

Seen in CI jobs from PRs, like this one: https://travis-ci.org/react-toolbox/react-toolbox/jobs/269849579