### PR TITLE
Remove box-shadow on required inputs

### DIFF
--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -41,6 +41,10 @@
   padding: var(--input-field-padding) 0;
   width: 100%;
 
+  &:required {
+    box-shadow: none;
+  }
+
   &:focus:not([disabled]):not([readonly]) {
     & ~ .bar::before,
     & ~ .bar::after {


### PR DESCRIPTION
Fixes #1639 

Before:
![screen shot 2017-09-18 at 19 56 57](https://user-images.githubusercontent.com/905225/30556628-c15fafbc-9cab-11e7-811a-ccf579eb4768.png)

After:
![screen shot 2017-09-18 at 19 56 47](https://user-images.githubusercontent.com/905225/30556633-c6383bbc-9cab-11e7-9f45-9fb4908ca4f4.png)

Tested using `Firefox 55.0.3`