### PR TITLE
Add title to <Avatar /> image

### DIFF
--- a/components/avatar/Avatar.js
+++ b/components/avatar/Avatar.js
@@ -10,7 +10,7 @@ const factory = (FontIcon) => {
     <div data-react-toolbox="avatar" className={classnames(theme.avatar, className)} {...other}>
       {children}
       {cover && typeof image === 'string' && <span aria-label={alt} className={theme.image} style={{ backgroundImage: `url(${image})` }} />}
-      {!cover && (typeof image === 'string' ? <img alt={alt} className={theme.image} src={image} /> : image)}
+      {!cover && (typeof image === 'string' ? <img alt={alt} className={theme.image} src={image} title={title} /> : image)}
       {typeof icon === 'string' ? <FontIcon className={theme.letter} value={icon} alt={alt} /> : icon}
       {title ? <span className={theme.letter}>{title[0]}</span> : null}
     </div>


### PR DESCRIPTION
Fixes #1673

The `title` attribute was removed [in this commit ](https://github.com/react-toolbox/react-toolbox/commit/3859c464ff0bc792b65f362167c4294c75a393ef) when adding the `alt` attribute, let's bring it back :)