### PR TITLE
Allow autoFocus on Autocomplete component

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -132,7 +132,7 @@ const factory = (Chip, Input) => {
     };
 
     handleQueryFocus = (event) => {
-      this.suggestionsNode.scrollTop = 0;
+      event.target.scrollTop = 0;
       this.setState({ active: '', focus: true });
       if (this.props.onFocus) this.props.onFocus(event);
     };
@@ -375,7 +375,6 @@ const factory = (Chip, Input) => {
       return (
         <ul
           className={classnames(theme.suggestions, { [theme.up]: this.state.direction === 'up' })}
-          ref={(node) => { this.suggestionsNode = node; }}
         >
           {suggestions}
         </ul>


### PR DESCRIPTION
Setting the `autoFocus` prop on `Autocomplete` has an error and does not show suggestions. See https://github.com/facebook/react/issues/7769 for the related React issue and the suggested workaround.
![autocomplete error](https://user-images.githubusercontent.com/1837091/30715710-2d8eaa40-9ecc-11e7-8e6b-084fa9144fab.png)
