### PR TITLE
Fix GitHub TextCase.

### DIFF
--- a/.bumpedrc
+++ b/.bumpedrc
@@ -29,7 +29,7 @@ plugins:
       plugin: 'bumped-terminal'
       command: 'git-dirty'
 
-    'Publishing tag at Github':
+    'Publishing tag at GitHub':
       plugin: 'bumped-terminal'
       command: 'git tag $newVersion && git push origin dev && git push --tags origin dev'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1488,7 +1488,7 @@
 * added bumped configuration ([6ad44d7](https://github.com/react-toolbox/react-toolbox/commit/6ad44d7))
 * Added component to Package and Bundle ([193ba8b](https://github.com/react-toolbox/react-toolbox/commit/193ba8b))
 * Added one-dark theme for editor ([236a373](https://github.com/react-toolbox/react-toolbox/commit/236a373))
-* Added publish in Github and NPM ([226d83d](https://github.com/react-toolbox/react-toolbox/commit/226d83d))
+* Added publish in GitHub and NPM ([226d83d](https://github.com/react-toolbox/react-toolbox/commit/226d83d))
 * Authors data for <Card> ([2f489eb](https://github.com/react-toolbox/react-toolbox/commit/2f489eb))
 * Babel to stage 2 and remove decorators ([7c43f93](https://github.com/react-toolbox/react-toolbox/commit/7c43f93))
 * Basic transition for Playground ([962b321](https://github.com/react-toolbox/react-toolbox/commit/962b321))
@@ -2006,6 +2006,3 @@
 * Bugfix: set animation iteration count as infinite in ripple loading ([76774a0](https://github.com/react-toolbox/react-toolbox/commit/76774a0))
 * Bugfix: set proper height for buttons ([0780c5a](https://github.com/react-toolbox/react-toolbox/commit/0780c5a))
 * Bugfix: take into account 24hr format when trimming hours in clock ([efdc0fa](https://github.com/react-toolbox/react-toolbox/commit/efdc0fa))
-
-
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <a href='http://react-toolbox.com'><img src='http://i.imgur.com/VCSElQX.png' height='50'></a>
 
-[![npm version](https://img.shields.io/npm/v/react-toolbox.svg?style=flat-square)](https://www.npmjs.com/package/react-toolbox) [![Build Status](http://img.shields.io/travis/react-toolbox/react-toolbox/master.svg?style=flat-square)](https://travis-ci.org/react-toolbox/react-toolbox) [![NPM Status](http://img.shields.io/npm/dm/react-toolbox.svg?style=flat-square)](https://www.npmjs.org/package/react-toolbox) [![Donate](https://img.shields.io/badge/donate-paypal-blue.svg?style=flat-square)](https://paypal.me/javivelasco) [![OpenCollective](https://opencollective.com/react-toolbox/backers/badge.svg)](#backers) 
+[![npm version](https://img.shields.io/npm/v/react-toolbox.svg?style=flat-square)](https://www.npmjs.com/package/react-toolbox) [![Build Status](http://img.shields.io/travis/react-toolbox/react-toolbox/master.svg?style=flat-square)](https://travis-ci.org/react-toolbox/react-toolbox) [![NPM Status](http://img.shields.io/npm/dm/react-toolbox.svg?style=flat-square)](https://www.npmjs.org/package/react-toolbox) [![Donate](https://img.shields.io/badge/donate-paypal-blue.svg?style=flat-square)](https://paypal.me/javivelasco) [![OpenCollective](https://opencollective.com/react-toolbox/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/react-toolbox/sponsors/badge.svg)](#sponsors)
 
 React Toolbox is a set of [React](http://facebook.github.io/react/) components that implement [Google's Material Design specification](https://material.google.com/). It's powered by [CSS Modules](https://github.com/css-modules/css-modules) and harmoniously integrates with your [webpack](http://webpack.github.io/) workflow, although you can use any other module bundler. You can take a tour through our documentation website and try the components live!
@@ -221,7 +221,7 @@ You can override both the global and component-specific CSS Custom Properties at
 ```js
 
 // This can also be stored in a separate file:
-const reactToolboxVariables = { 
+const reactToolboxVariables = {
   'color-text': '#444548',
   /* Note that you can use global colors and variables */
   'color-primary': 'var(--palette-blue-500)',
@@ -359,7 +359,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 
 ### Sponsors
-Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/react-toolbox#sponsor)]
+Become a sponsor and get your logo on our README on GitHub with a link to your site. [[Become a sponsor](https://opencollective.com/react-toolbox#sponsor)]
 
 <a href="https://opencollective.com/react-toolbox/sponsor/0/website" target="_blank"><img src="https://opencollective.com/react-toolbox/sponsor/0/avatar.svg"></a>
 <a href="https://opencollective.com/react-toolbox/sponsor/1/website" target="_blank"><img src="https://opencollective.com/react-toolbox/sponsor/1/avatar.svg"></a>

--- a/components/button/readme.md
+++ b/components/button/readme.md
@@ -15,7 +15,7 @@ const GithubIcon = () => (
 const TestButtons = () => (
   <div>
     <Button href='http://github.com/javivelasco' target='_blank' raised>
-      <GithubIcon /> Github
+      <GithubIcon /> GitHub
     </Button>
     <Button icon='bookmark' label='Bookmark' accent />
     <Button icon='bookmark' label='Bookmark' raised primary />

--- a/docs/app/components/layout/home/index.js
+++ b/docs/app/components/layout/home/index.js
@@ -63,7 +63,7 @@ const Home = () => (
           <CardTitle title="Javi Velasco" subtitle="@javivelasco" />
           <CardText>Software gardener • Film, music & comic lover • Frontend Engineer at Audiense  • Any biographer in the room?</CardText>
           <CardActions>
-            <Button href="http://github.com/javivelasco" target="_blank"><GithubIcon /> Github</Button>
+            <Button href="http://github.com/javivelasco" target="_blank"><GithubIcon /> GitHub</Button>
             <Button href="http://twitter.com/javivelasco" theme={style} target="_blank" className={style.twitterButton}><TwitterIcon /> Twitter</Button>
           </CardActions>
         </Card>
@@ -73,7 +73,7 @@ const Home = () => (
           <CardTitle title="Javi Jiménez" subtitle="@soyjavi" />
           <CardText>Creative Doer · A complicated #human who builds stuff · #author · #opensource lover · #traveller · with a dark past being CEO & CTO</CardText>
           <CardActions>
-            <Button href="http://github.com/soyjavi" target="_blank"><GithubIcon /> Github</Button>
+            <Button href="http://github.com/soyjavi" target="_blank"><GithubIcon /> GitHub</Button>
             <Button href="http://twitter.com/soyjavi" theme={style} target="_blank" className={style.twitterButton}><TwitterIcon /> Twitter</Button>
           </CardActions>
         </Card>

--- a/docs/app/components/layout/main/modules/examples/button_example_1.txt
+++ b/docs/app/components/layout/main/modules/examples/button_example_1.txt
@@ -7,7 +7,7 @@ const GithubIcon = () => (
 const ButtonsTest = () => (
   <div>
     <Button href='http://github.com/javivelasco' target='_blank' raised>
-      <GithubIcon /> Github
+      <GithubIcon /> GitHub
     </Button>
     <Button icon='bookmark' label='Bookmark' accent />
     <Button icon='bookmark' label='Bookmark' raised primary />

--- a/spec/components/button.js
+++ b/spec/components/button.js
@@ -8,7 +8,7 @@ const ButtonTest = () => (
     <p>lorem ipsum...</p>
 
     <Button href="http://github.com/javivelasco" target="_blank" raised>
-      <GithubIcon /> Github
+      <GithubIcon /> GitHub
     </Button>
     <Button icon="bookmark" label="Bookmark" accent onRippleEnded={rippleEnded} />
     <Button icon="bookmark" label="Bookmark" raised primary rippleMultiple={false} onRippleEnded={rippleEnded} />
@@ -35,7 +35,7 @@ const ButtonTest = () => (
     <IconButton icon="menu" />
     <span style={{ verticalAlign: 'middle' }}>Menu</span>
     <IconButton><GithubIcon /></IconButton>
-    <span style={{ verticalAlign: 'middle' }}>Github</span>
+    <span style={{ verticalAlign: 'middle' }}>GitHub</span>
     <h5>Browse Button</h5>
     <br />
     <BrowseButton icon="folder_open" label="BROWSE" raised primary />

--- a/spec/components/link.js
+++ b/spec/components/link.js
@@ -5,7 +5,7 @@ const LinkTest = () => (
   <section>
     <h5>Links</h5>
     <p>lorem ipsum...</p>
-    <Link label="Github" route="http://www.github.com" icon="bookmark" />
+    <Link label="GitHub" route="http://www.github.com" icon="bookmark" />
     <Link label="Inbox" route="http://mail.google.com" icon="inbox" />
   </section>
 );

--- a/spec/ts/button.tsx
+++ b/spec/ts/button.tsx
@@ -8,7 +8,7 @@ const ButtonTest = () => (
     <p>lorem ipsum...</p>
 
     <Button href="http://github.com/javivelasco" target="_blank" raised>
-      <GithubIcon /> Github
+      <GithubIcon /> GitHub
     </Button>
     <Button icon="bookmark" label="Bookmark" accent onRippleEnded={rippleEnded} />
     <Button icon="bookmark" label="Bookmark" raised primary rippleMultiple={false} onRippleEnded={rippleEnded} />
@@ -35,7 +35,7 @@ const ButtonTest = () => (
     <IconButton icon="menu" />
     <span style={{ verticalAlign: 'middle' }}>Menu</span>
     <IconButton><GithubIcon /></IconButton>
-    <span style={{ verticalAlign: 'middle' }}>Github</span>
+    <span style={{ verticalAlign: 'middle' }}>GitHub</span>
     <h5>Browse Button</h5>
     <br />
     <BrowseButton icon="folder_open" label="BROWSE" raised primary />

--- a/spec/ts/link.tsx
+++ b/spec/ts/link.tsx
@@ -5,7 +5,7 @@ const LinkTest = () => (
   <section>
     <h5>Links</h5>
     <p>lorem ipsum...</p>
-    <Link label="Github" route="http://www.github.com" icon="bookmark" />
+    <Link label="GitHub" route="http://www.github.com" icon="bookmark" />
     <Link label="Inbox" route="http://mail.google.com" icon="inbox" />
   </section>
 );


### PR DESCRIPTION
The correct notation of GitHub is "GitHub".
But, since it was "Github" on the document, I fixed it.
`(s/Github/Github/g , exclude <GithubIcon />)`