### PR TITLE
Allow custom knob renderer on Slider

### DIFF
--- a/components/slider/Slider.js
+++ b/components/slider/Slider.js
@@ -23,6 +23,7 @@ const factory = (ProgressBar, Input) => {
       onDragStart: PropTypes.func,
       onDragStop: PropTypes.func,
       pinned: PropTypes.bool,
+      renderKnob: PropTypes.func,
       snaps: PropTypes.bool,
       step: PropTypes.number,
       style: styleShape,
@@ -53,6 +54,7 @@ const factory = (ProgressBar, Input) => {
       onDragStart: () => {},
       onDragStop: () => {},
       pinned: false,
+      renderKnob: value => parseInt(value, 10),
       snaps: false,
       step: 0.01,
       value: 0,
@@ -304,7 +306,10 @@ const factory = (ProgressBar, Input) => {
               onTouchStart={this.handleTouchStart}
               style={knobStyles}
             >
-              <div className={theme.innerknob} data-value={parseInt(this.props.value, 10)} />
+              <div
+                className={theme.innerknob}
+                data-value={this.props.renderKnob(this.props.value)}
+              />
             </div>
 
             <div className={theme.progress}>


### PR DESCRIPTION
Using a floating step (eg. 0.5) leads to confusing knob on Slider. This would allow to override the `parseInt` used for the knob value.
Let me know if you're ok w/ the changes, I'll update the tests & doc then.