### PR TITLE
Add config file for circleci 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:latest
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          # Increment prefix to v2 when it's needed to manually reset cache
+          - v1-dependencies-{{ checksum "yarn.lock" }}
+          - v1-dependencies-
+
+      # Yarn is included in the image
+      - run: yarn install --frozen-lockfile
+
+      # Fetch npx to easily run testing suite on any node version (or other dependencies versions like React 16)
+      - run: sudo npm install -g npx
+
+      # Runs in latest release of node
+      - run: make test-ci
+
+      # Run suite on LTS node
+      - run: npx -p node-bin@lts -- make test-ci
+      
+      # Example how to run the suite on a different version of react
+      # - run: npx -p react@15.6.1 -p react-dom@15.6.1 react-test-renderer@15.6.1 -- make test-ci
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
CircleCI is awesome! Added the config file needed to get started.
To enable the builds someone with admin rights need to go here: https://circleci.com/gh/react-toolbox/react-toolbox

Benefits:
* The docker image they use already include yarn and the latest version of node (no need for nvm like travis uses) makes builds faster. Two test runs on different node versions instead of two separate containers.
* Dynamic caching, so far didn't have enough knowledge about the project to go beyond caching node_modules.
* Tooling like yarn and jest supports colored output making CI reports much more readable.

