### PR TITLE
v1 react16 compat

### DIFF
--- a/components/app_bar/AppBar.js
+++ b/components/app_bar/AppBar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { APP_BAR } from '../identifiers.js';

--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
@@ -20,14 +21,14 @@ const factory = (Chip, Input) => {
      className: PropTypes.string,
      direction: PropTypes.oneOf(['auto', 'up', 'down']),
      disabled: PropTypes.bool,
-     error: React.PropTypes.oneOfType([
-       React.PropTypes.string,
-       React.PropTypes.node
+     error: PropTypes.oneOfType([
+       PropTypes.string,
+       PropTypes.node
      ]),
      keepFocusOnChange: PropTypes.bool,
-     label: React.PropTypes.oneOfType([
-       React.PropTypes.string,
-       React.PropTypes.node
+     label: PropTypes.oneOfType([
+       PropTypes.string,
+       PropTypes.node
      ]),
      multiple: PropTypes.bool,
      onBlur: PropTypes.func,

--- a/components/avatar/Avatar.js
+++ b/components/avatar/Avatar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { AVATAR } from '../identifiers.js';

--- a/components/button/BrowseButton.js
+++ b/components/button/BrowseButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { BUTTON } from '../identifiers.js';

--- a/components/button/Button.js
+++ b/components/button/Button.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { BUTTON } from '../identifiers.js';

--- a/components/button/IconButton.js
+++ b/components/button/IconButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { BUTTON } from '../identifiers.js';

--- a/components/button/__test__/index.spec.js
+++ b/components/button/__test__/index.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import theme from '../theme.scss';
 import Button, { Button as RawButton } from '../Button';
 

--- a/components/card/Card.js
+++ b/components/card/Card.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardActions.js
+++ b/components/card/CardActions.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardMedia.js
+++ b/components/card/CardMedia.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardText.js
+++ b/components/card/CardText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { CARD } from '../identifiers.js';

--- a/components/card/CardTitle.js
+++ b/components/card/CardTitle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { CARD } from '../identifiers.js';

--- a/components/checkbox/Check.js
+++ b/components/checkbox/Check.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 
 const factory = (ripple) => {

--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { CHECKBOX } from '../identifiers.js';

--- a/components/chip/Chip.js
+++ b/components/chip/Chip.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { CHIP } from '../identifiers.js';

--- a/components/chip/__test__/index.spec.js
+++ b/components/chip/__test__/index.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import { themr } from 'react-css-themr';
 import { CHIP } from '../../identifiers.js';
 import { chipFactory } from '../Chip';

--- a/components/date_picker/Calendar.js
+++ b/components/date_picker/Calendar.js
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react';
-import CssTransitionGroup from 'react-addons-css-transition-group';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import CssTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { SlideLeft, SlideRight } from '../animations';
 import time from '../utils/time.js';
 import utils from '../utils/utils.js';
@@ -10,19 +11,19 @@ const DIRECTION_STEPS = { left: -1, right: 1 };
 const factory = (IconButton) => {
   class Calendar extends Component {
     static propTypes = {
-      disabledDates: React.PropTypes.array,
+      disabledDates: PropTypes.array,
       display: PropTypes.oneOf(['months', 'years']),
-      enabledDates: React.PropTypes.array,
+      enabledDates: PropTypes.array,
       handleSelect: PropTypes.func,
-      locale: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.object
+      locale: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
       ]),
       maxDate: PropTypes.object,
       minDate: PropTypes.object,
       onChange: PropTypes.func,
       selectedDate: PropTypes.object,
-      sundayFirstDayOfWeek: React.PropTypes.bool,
+      sundayFirstDayOfWeek: PropTypes.bool,
       theme: PropTypes.shape({
         active: PropTypes.string,
         calendar: PropTypes.string,

--- a/components/date_picker/CalendarDay.js
+++ b/components/date_picker/CalendarDay.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import time from '../utils/time.js';
 

--- a/components/date_picker/CalendarMonth.js
+++ b/components/date_picker/CalendarMonth.js
@@ -1,21 +1,22 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import time from '../utils/time.js';
 import utils from '../utils/utils.js';
 import CalendarDay from './CalendarDay.js';
 
 class Month extends Component {
   static propTypes = {
-    disabledDates: React.PropTypes.array,
-    enabledDates: React.PropTypes.array,
-    locale: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+    disabledDates: PropTypes.array,
+    enabledDates: PropTypes.array,
+    locale: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object
     ]),
     maxDate: PropTypes.object,
     minDate: PropTypes.object,
     onDayClick: PropTypes.func,
     selectedDate: PropTypes.object,
-    sundayFirstDayOfWeek: React.PropTypes.bool,
+    sundayFirstDayOfWeek: PropTypes.bool,
     theme: PropTypes.shape({
       days: PropTypes.string,
       month: PropTypes.string,

--- a/components/date_picker/DatePicker.js
+++ b/components/date_picker/DatePicker.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { DATE_PICKER } from '../identifiers.js';
@@ -18,8 +19,8 @@ const factory = (Input, DatePickerDialog) => {
       autoOk: PropTypes.bool,
       cancelLabel: PropTypes.string,
       className: PropTypes.string,
-      disabledDates: React.PropTypes.array,
-      enabledDates: React.PropTypes.array,
+      disabledDates: PropTypes.array,
+      enabledDates: PropTypes.array,
       error: PropTypes.string,
       icon: PropTypes.oneOfType([
         PropTypes.string,
@@ -28,9 +29,9 @@ const factory = (Input, DatePickerDialog) => {
       inputClassName: PropTypes.string,
       inputFormat: PropTypes.func,
       label: PropTypes.string,
-      locale: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.object
+      locale: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
       ]),
       maxDate: PropTypes.object,
       minDate: PropTypes.object,
@@ -43,7 +44,7 @@ const factory = (Input, DatePickerDialog) => {
       onKeyPress: PropTypes.func,
       onOverlayClick: PropTypes.func,
       readonly: PropTypes.bool,
-      sundayFirstDayOfWeek: React.PropTypes.bool,
+      sundayFirstDayOfWeek: PropTypes.bool,
       theme: PropTypes.shape({
         input: PropTypes.string
       }),

--- a/components/date_picker/DatePickerDialog.js
+++ b/components/date_picker/DatePickerDialog.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import time from '../utils/time.js';
 
@@ -11,9 +12,9 @@ const factory = (Dialog, Calendar) => {
       className: PropTypes.string,
       disabledDates: PropTypes.array,
       enabledDates: PropTypes.array,
-      locale: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.object
+      locale: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
       ]),
       maxDate: PropTypes.object,
       minDate: PropTypes.object,
@@ -23,7 +24,7 @@ const factory = (Dialog, Calendar) => {
       onEscKeyDown: PropTypes.func,
       onOverlayClick: PropTypes.func,
       onSelect: PropTypes.func,
-      sundayFirstDayOfWeek: React.PropTypes.bool,
+      sundayFirstDayOfWeek: PropTypes.bool,
       theme: PropTypes.shape({
         button: PropTypes.string,
         calendarWrapper: PropTypes.string,

--- a/components/dialog/Dialog.js
+++ b/components/dialog/Dialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { DIALOG } from '../identifiers.js';

--- a/components/drawer/Drawer.js
+++ b/components/drawer/Drawer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { DRAWER } from '../identifiers.js';

--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';

--- a/components/dropdown/__test__/index.spec.js
+++ b/components/dropdown/__test__/index.spec.js
@@ -4,7 +4,7 @@ import {
   renderIntoDocument,
   scryRenderedDOMComponentsWithClass,
   Simulate
-} from 'react-addons-test-utils';
+} from 'react-dom/test-utils';
 import sinon from 'sinon';
 import theme from '../theme.scss';
 import Dropdown from '../Dropdown';

--- a/components/font_icon/FontIcon.js
+++ b/components/font_icon/FontIcon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 
 const FontIcon = ({ children, className, value, ...other}) => (

--- a/components/form/Form.js
+++ b/components/form/Form.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import InjectAutocomplete from '../autocomplete/Autocomplete.js';
 import InjectButton from '../button/Button.js';
 import InjectCheckbox from '../checkbox/Checkbox.js';

--- a/components/hoc/ActivableRenderer.js
+++ b/components/hoc/ActivableRenderer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 const ActivableRendererFactory = (options = {delay: 500}) =>
   ActivableComponent => class ActivableRenderer extends Component {

--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 
 class Portal extends Component {

--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
@@ -7,51 +8,51 @@ import InjectedFontIcon from '../font_icon/FontIcon.js';
 const factory = (FontIcon) => {
   class Input extends React.Component {
     static propTypes = {
-      children: React.PropTypes.any,
-      className: React.PropTypes.string,
-      disabled: React.PropTypes.bool,
-      error: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.node
+      children: PropTypes.any,
+      className: PropTypes.string,
+      disabled: PropTypes.bool,
+      error: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node
       ]),
-      floating: React.PropTypes.bool,
-      hint: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.node
+      floating: PropTypes.bool,
+      hint: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node
       ]),
-      icon: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.element
+      icon: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element
       ]),
-      label: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.node
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.node
       ]),
-      maxLength: React.PropTypes.number,
-      multiline: React.PropTypes.bool,
-      name: React.PropTypes.string,
-      onBlur: React.PropTypes.func,
-      onChange: React.PropTypes.func,
-      onFocus: React.PropTypes.func,
-      onKeyPress: React.PropTypes.func,
-      required: React.PropTypes.bool,
-      rows: React.PropTypes.number,
-      theme: React.PropTypes.shape({
-        bar: React.PropTypes.string,
-        counter: React.PropTypes.string,
-        disabled: React.PropTypes.string,
-        error: React.PropTypes.string,
-        errored: React.PropTypes.string,
-        hidden: React.PropTypes.string,
-        hint: React.PropTypes.string,
-        icon: React.PropTypes.string,
-        input: React.PropTypes.string,
-        inputElement: React.PropTypes.string,
-        required: React.PropTypes.string,
-        withIcon: React.PropTypes.string
+      maxLength: PropTypes.number,
+      multiline: PropTypes.bool,
+      name: PropTypes.string,
+      onBlur: PropTypes.func,
+      onChange: PropTypes.func,
+      onFocus: PropTypes.func,
+      onKeyPress: PropTypes.func,
+      required: PropTypes.bool,
+      rows: PropTypes.number,
+      theme: PropTypes.shape({
+        bar: PropTypes.string,
+        counter: PropTypes.string,
+        disabled: PropTypes.string,
+        error: PropTypes.string,
+        errored: PropTypes.string,
+        hidden: PropTypes.string,
+        hint: PropTypes.string,
+        icon: PropTypes.string,
+        input: PropTypes.string,
+        inputElement: PropTypes.string,
+        required: PropTypes.string,
+        withIcon: PropTypes.string
       }),
-      type: React.PropTypes.string,
-      value: React.PropTypes.any
+      type: PropTypes.string,
+      value: PropTypes.any
     };
 
     static defaultProps = {

--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import classnames from 'classnames';
 import { LAYOUT } from '../identifiers.js';

--- a/components/layout/NavDrawer.js
+++ b/components/layout/NavDrawer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LAYOUT } from '../identifiers.js';

--- a/components/layout/Panel.js
+++ b/components/layout/Panel.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LAYOUT } from '../identifiers.js';

--- a/components/layout/Sidebar.js
+++ b/components/layout/Sidebar.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LAYOUT } from '../identifiers.js';

--- a/components/link/Link.js
+++ b/components/link/Link.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LINK } from '../identifiers.js';

--- a/components/list/List.js
+++ b/components/list/List.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListCheckbox.js
+++ b/components/list/ListCheckbox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListDivider.js
+++ b/components/list/ListDivider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';
 

--- a/components/list/ListItem.js
+++ b/components/list/ListItem.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';
 import InjectListItemContent from './ListItemContent.js';

--- a/components/list/ListItemAction.js
+++ b/components/list/ListItemAction.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';
 

--- a/components/list/ListItemActions.js
+++ b/components/list/ListItemActions.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';
 import InjectListItemAction from './ListItemAction.js';

--- a/components/list/ListItemContent.js
+++ b/components/list/ListItemContent.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListItemLayout.js
+++ b/components/list/ListItemLayout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListItemText.js
+++ b/components/list/ListItemText.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/list/ListSubHeader.js
+++ b/components/list/ListSubHeader.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { LIST } from '../identifiers.js';

--- a/components/menu/IconMenu.js
+++ b/components/menu/IconMenu.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { MENU } from '../identifiers.js';

--- a/components/menu/Menu.js
+++ b/components/menu/Menu.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';

--- a/components/menu/MenuDivider.js
+++ b/components/menu/MenuDivider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { themr } from 'react-css-themr';
 import { MENU } from '../identifiers.js';
 

--- a/components/menu/MenuItem.js
+++ b/components/menu/MenuItem.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { MENU } from '../identifiers.js';

--- a/components/menu/__test__/index.spec.js
+++ b/components/menu/__test__/index.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 import Menu from '../Menu';
 import MenuItem, {MenuItem as RawMenuItem} from '../MenuItem';
 

--- a/components/navigation/Navigation.js
+++ b/components/navigation/Navigation.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { NAVIGATION } from '../identifiers.js';

--- a/components/overlay/Overlay.js
+++ b/components/overlay/Overlay.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { OVERLAY } from '../identifiers.js';

--- a/components/progress_bar/ProgressBar.js
+++ b/components/progress_bar/ProgressBar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { PROGRESS_BAR } from '../identifiers.js';

--- a/components/progress_bar/__test__/index.spec.js
+++ b/components/progress_bar/__test__/index.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import expect from 'expect';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import ProgressBar, { ProgressBar as RawProgressBar } from '../ProgressBar';
 import theme from '../theme.scss';
 import utils from '../../utils/testing';

--- a/components/radio/Radio.js
+++ b/components/radio/Radio.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const factory = (ripple) => {
   const Radio = ({checked, onMouseDown, theme, ...other}) => (

--- a/components/radio/RadioButton.js
+++ b/components/radio/RadioButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { RADIO } from '../identifiers.js';

--- a/components/radio/RadioGroup.js
+++ b/components/radio/RadioGroup.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { themr } from 'react-css-themr';
 import { RADIO } from '../identifiers.js';
 import InjectRadioButton from './RadioButton.js';

--- a/components/ripple/Ripple.js
+++ b/components/ripple/Ripple.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import update from 'immutability-helper';

--- a/components/slider/Slider.js
+++ b/components/slider/Slider.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';

--- a/components/slider/__tests__/index.spec.js
+++ b/components/slider/__tests__/index.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
 import expect from 'expect';
 import { ProgressBar } from '../../progress_bar/ProgressBar.js';

--- a/components/snackbar/Snackbar.js
+++ b/components/snackbar/Snackbar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { SNACKBAR } from '../identifiers.js';

--- a/components/switch/Switch.js
+++ b/components/switch/Switch.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { SWITCH } from '../identifiers.js';

--- a/components/switch/Thumb.js
+++ b/components/switch/Thumb.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const factory = (ripple) => {
   const Thumb = ({onMouseDown, theme, ...other}) => (

--- a/components/table/Table.js
+++ b/components/table/Table.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { TABLE } from '../identifiers.js';

--- a/components/table/TableHead.js
+++ b/components/table/TableHead.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const factory = (Checkbox) => {
   const TableHead = ({model, onSelect, selectable, multiSelectable, selected, theme}) => {

--- a/components/table/TableRow.js
+++ b/components/table/TableRow.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import utils from '../utils/utils';
 

--- a/components/tabs/Tab.js
+++ b/components/tabs/Tab.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { FontIcon } from '../font_icon';
 import { themr } from 'react-css-themr';

--- a/components/tabs/TabContent.js
+++ b/components/tabs/TabContent.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { TABS } from '../identifiers.js';

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { TABS } from '../identifiers.js';

--- a/components/tabs/__tests__/index.spec.js
+++ b/components/tabs/__tests__/index.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import utils from '../../utils/testing';
-import ReactTestUtils from 'react-addons-test-utils';
+import ReactTestUtils from 'react-dom/test-utils';
 
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';

--- a/components/time_picker/Clock.js
+++ b/components/time_picker/Clock.js
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react';
-import CssTransitionGroup from 'react-addons-css-transition-group';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import CssTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import { ZoomIn, ZoomOut } from '../animations';
 import time from '../utils/time.js';
 import Hours from './ClockHours.js';

--- a/components/time_picker/ClockFace.js
+++ b/components/time_picker/ClockFace.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 
 class Face extends Component {

--- a/components/time_picker/ClockHand.js
+++ b/components/time_picker/ClockHand.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import events from '../utils/events.js';
 import prefixer from '../utils/prefixer.js';
 import utils from '../utils/utils.js';

--- a/components/time_picker/ClockHours.js
+++ b/components/time_picker/ClockHours.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import utils from '../utils/utils.js';
 import Hand from './ClockHand.js';
 import Face from './ClockFace.js';

--- a/components/time_picker/ClockMinutes.js
+++ b/components/time_picker/ClockMinutes.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import utils from '../utils/utils.js';
 import Hand from './ClockHand.js';
 import Face from './ClockFace.js';

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';
 import { TIME_PICKER } from '../identifiers.js';

--- a/components/time_picker/TimePickerDialog.js
+++ b/components/time_picker/TimePickerDialog.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import classnames from 'classnames';
 import time from '../utils/time.js';
 import Clock from './Clock.js';

--- a/components/tooltip/Tooltip.js
+++ b/components/tooltip/Tooltip.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Portal from '../hoc/Portal';
 import classnames from 'classnames';
 import { themr } from 'react-css-themr';

--- a/components/utils/testing.js
+++ b/components/utils/testing.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
+import ShallowRenderer from 'react-test-renderer/shallow';
 
 export default {
   renderComponent (Component, props = {}, state = {}) {
@@ -9,7 +10,7 @@ export default {
   },
 
   shallowRenderComponent (component, props, ...children) {
-    const shallowRenderer = TestUtils.createRenderer();
+    const shallowRenderer = new ShallowRenderer();
     shallowRenderer.render(React.createElement(component, props, children.length > 1 ? children : children[0]));
     return shallowRenderer.getRenderOutput();
   }

--- a/docs/app/components/appbar/index.js
+++ b/docs/app/components/appbar/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { AppBar } from 'react-toolbox';
 import { Link } from 'react-router';
 import Logo from '../logo';
@@ -20,7 +21,7 @@ const MainAppBar = (props) => {
 };
 
 MainAppBar.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 MainAppBar.defaultProps = {

--- a/docs/app/components/editor/index.js
+++ b/docs/app/components/editor/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from './style';
 import CodeMirror from 'codemirror';
@@ -5,13 +6,13 @@ import 'codemirror/mode/javascript/javascript';
 
 class Editor extends React.Component {
   static propTypes = {
-    className: React.PropTypes.string,
-    codeText: React.PropTypes.string,
-    lineNumbers: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
-    readOnly: React.PropTypes.bool,
-    tabSize: React.PropTypes.number,
-    theme: React.PropTypes.string
+    className: PropTypes.string,
+    codeText: PropTypes.string,
+    lineNumbers: PropTypes.bool,
+    onChange: PropTypes.func,
+    readOnly: PropTypes.bool,
+    tabSize: PropTypes.number,
+    theme: PropTypes.string
   };
 
   static defaultProps = {

--- a/docs/app/components/layout/main/components/navigation.js
+++ b/docs/app/components/layout/main/components/navigation.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { List, ListItem } from 'react-toolbox';
 import classnames from 'classnames';
 import components from '../modules/components';

--- a/docs/app/components/layout/main/components/playground.js
+++ b/docs/app/components/layout/main/components/playground.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Editor from '../../../editor';
 import Preview from '../../../preview';
@@ -6,7 +7,7 @@ import style from './playground.scss';
 
 class Playground extends React.Component {
   static propTypes = {
-    className: React.PropTypes.string
+    className: PropTypes.string
   };
 
   state = {

--- a/docs/app/components/layout/main/index.js
+++ b/docs/app/components/layout/main/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Button } from 'react-toolbox';
@@ -22,13 +23,13 @@ const LoadExampleButton = (props) => (
 );
 
 LoadExampleButton.propTypes = {
-  onClick: React.PropTypes.func
+  onClick: PropTypes.func
 };
 
 class Main extends React.Component {
   static propTypes = {
-    onClick: React.PropTypes.func,
-    params: React.PropTypes.object
+    onClick: PropTypes.func,
+    params: PropTypes.object
   };
 
   state = {

--- a/docs/app/components/logo/index.js
+++ b/docs/app/components/logo/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from './style';
 
@@ -16,7 +17,7 @@ const Logo = (props) => {
 };
 
 Logo.propTypes = {
-  className: React.PropTypes.string
+  className: PropTypes.string
 };
 
 export default Logo;

--- a/docs/app/components/markdown/index.js
+++ b/docs/app/components/markdown/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import style from './style';
 
@@ -13,8 +14,8 @@ const Markdown = (props) => {
 };
 
 Markdown.propTypes = {
-  className: React.PropTypes.string,
-  markdown: React.PropTypes.string.isRequired
+  className: PropTypes.string,
+  markdown: PropTypes.string.isRequired
 };
 
 Markdown.defaultProps = {

--- a/docs/app/components/navigation/index.js
+++ b/docs/app/components/navigation/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 
@@ -14,8 +15,8 @@ const Navigation = (props) => {
 };
 
 Navigation.propTypes = {
-  activeClassName: React.PropTypes.string,
-  className: React.PropTypes.string
+  activeClassName: PropTypes.string,
+  className: PropTypes.string
 };
 
 

--- a/docs/app/components/preview/index.js
+++ b/docs/app/components/preview/index.js
@@ -1,4 +1,6 @@
 /*eslint-disable no-eval*/
+import PropTypes from 'prop-types';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ThemeProvider } from 'react-css-themr';
@@ -11,9 +13,9 @@ const ERROR_TIMEOUT = 500;
 
 const Preview = React.createClass({
   propTypes: {
-    className: React.PropTypes.string,
-    code: React.PropTypes.string.isRequired,
-    scope: React.PropTypes.object
+    className: PropTypes.string,
+    code: PropTypes.string.isRequired,
+    scope: PropTypes.object
   },
 
   getDefaultProps () {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ const webpackConfig = require('./webpack.config.test');
 
 module.exports = function (config) {
   config.set({
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome', 'PhantomJS'],
     singleRun: true,
     frameworks: ['mocha'],
     files: [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "core-js": "^2.4.0",
     "immutability-helper": "^2.0.0",
     "normalize.css": "^4.2.0",
-    "react-css-themr": "^1.7.1"
+    "prop-types": "^15.6.0",
+    "react-css-themr": "git://github.com/bionikspoon/react-css-themr.git#react_16_build"
   },
   "devDependencies": {
     "autoprefixer": "^6.5.4",
@@ -80,12 +81,12 @@
     "phantomjs-prebuilt": "^2.1.14",
     "postcss-loader": "^1.2.1",
     "pre-commit": "^1.2.2",
-    "react": "^15.4.1",
-    "react-addons-css-transition-group": "^15.4.1",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
+    "react-transition-group": "^1.2.1",
     "redbox-react": "^1.3.2",
     "rimraf": "^2.5.2",
     "sass-lint": "^1.10.2",
@@ -116,9 +117,9 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14 || ~15.4.0",
+    "react": "^0.14 || ~15.4.0 || ^16.0.0",
     "react-addons-css-transition-group": "^0.14.0 || ~15.4.0",
-    "react-dom": "^0.14.0 || ~15.4.0"
+    "react-dom": "^0.14.0 || ~15.4.0 || ^16.0.0"
   },
   "pre-commit": "lint:staged"
 }

--- a/spec/components/dialog.js
+++ b/spec/components/dialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Button from '../../components/button';
 import Dialog from '../../components/dialog';
 import Dropdown from '../../components/dropdown';


### PR DESCRIPTION
Fixes #1715, Fixes #1703

- remove references to `React.PropTypes`
- fixed other removed imports

Note: Meant to be based on `tag:1.3.4`