### PR TITLE
Fix dropdown entry selection issue

### DIFF
--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -99,6 +99,7 @@ const factory = (Input) => {
     };
 
     handleSelect = (item, event) => {
+      event.preventDefault()
       if (this.props.onBlur) this.props.onBlur(event);
       if (!this.props.disabled && this.props.onChange) {
         if (this.props.name) event.target.name = this.props.name;


### PR DESCRIPTION
Currently a user have to click twice on an entry within the dropdown
list to close it. This happens because the li click event will call
'handleSelect' and the default behavior calls 'handleDocumentClick'.
This is wrong when the user clicks on an entry (and not outside of
the dropdown) so now the 'handleSelect' prevents the default behaviour.