### PR TITLE
Use window.requestAnimationFrame in Tabs.js

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -83,7 +83,7 @@ const factory = (Tab, TabContent, FontIcon) => {
 
     updatePointer = (idx) => {
       if (this.navigationNode && this.navigationNode.children[idx]) {
-        this.updatePointerAnimationFrame = requestAnimationFrame(() => {
+        this.updatePointerAnimationFrame = window.requestAnimationFrame(() => {
           const nav = this.navigationNode.getBoundingClientRect();
           const label = this.navigationNode.children[idx].getBoundingClientRect();
           const scrollLeft = this.navigationNode.scrollLeft;


### PR DESCRIPTION
Call requestAnimationFrame on window object to fix headless testing
with jsdom without hacking around by defining global vars