### PR TITLE
Update defaults in input component config.css

### DIFF
--- a/components/input/config.css
+++ b/components/input/config.css
@@ -6,8 +6,9 @@
   --input-label-font-size: calc(1.2 * var(--unit));
   --input-focus-label-top: calc(0.6 * var(--unit));
   --input-text-background-color: transparent;
-  --input-text-label-color: color(var(--color-black) a(26%));
-  --input-text-bottom-border-color: color(var(--color-black) a(12%));
+  --input-text-label-color: color(var(--color-text) a(26%));
+  --input-text-input-element-color: var(--color-text);
+  --input-text-bottom-border-color: color(var(--color-text) a(12%));
   --input-text-highlight-color: var(--color-primary);
   --input-text-disabled-color: var(--input-text-bottom-border-color);
   --input-text-disabled-text-color: var(--input-text-label-color);

--- a/components/input/theme.css
+++ b/components/input/theme.css
@@ -34,7 +34,7 @@
   border-radius: 0;
   border-right: 0;
   border-top: 0;
-  color: var(--color-text);
+  color: var(--input-text-input-element-color);
   display: block;
   font-size: var(--input-field-font-size);
   outline: none;


### PR DESCRIPTION
Use color-text variable for label and border color. This seems like an intuitive default since the default background is transparent. 
Also, the input element needs the option to set a custom color value, otherwise setting a custom background is limited to what works with the overall text-color.