### PR TITLE
Fix TimePicker dismiss issue

### DIFF
--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -59,8 +59,6 @@ const factory = (Tab, TabContent, FontIcon) => {
       if (index !== prevIndex || children !== prevChildren) {
         this.updatePointer(index);
       }
-
-      this.updateArrows();
     }
 
     componentWillUnmount() {
@@ -107,18 +105,13 @@ const factory = (Tab, TabContent, FontIcon) => {
         const scrollLeft = this.navigationNode.scrollLeft;
         const nav = this.navigationNode.getBoundingClientRect();
         const lastLabel = this.navigationNode.children[idx].getBoundingClientRect();
-        const left = scrollLeft > 0;
-        const right = nav.right < (lastLabel.right - 5);
-        const { left: prevLeft, right: prevRight } = this.state.arrows;
 
-        if (left !== prevLeft || right !== prevRight) {
-          this.setState({
-            arrows: {
-              left,
-              right,
-            },
-          });
-        }
+        this.setState({
+          arrows: {
+            left: scrollLeft > 0,
+            right: nav.right < (lastLabel.right - 5),
+          },
+        });
       }
     }
 

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -59,6 +59,8 @@ const factory = (Tab, TabContent, FontIcon) => {
       if (index !== prevIndex || children !== prevChildren) {
         this.updatePointer(index);
       }
+
+      this.updateArrows();
     }
 
     componentWillUnmount() {
@@ -105,13 +107,18 @@ const factory = (Tab, TabContent, FontIcon) => {
         const scrollLeft = this.navigationNode.scrollLeft;
         const nav = this.navigationNode.getBoundingClientRect();
         const lastLabel = this.navigationNode.children[idx].getBoundingClientRect();
+        const left = scrollLeft > 0;
+        const right = nav.right < (lastLabel.right - 5);
+        const { left: prevLeft, right: prevRight } = this.state.arrows;
 
-        this.setState({
-          arrows: {
-            left: scrollLeft > 0,
-            right: nav.right < (lastLabel.right - 5),
-          },
-        });
+        if (left !== prevLeft || right !== prevRight) {
+          this.setState({
+            arrows: {
+              left,
+              right,
+            },
+          });
+        }
       }
     }
 

--- a/components/time_picker/TimePicker.js
+++ b/components/time_picker/TimePicker.js
@@ -117,8 +117,8 @@ const factory = (TimePickerDialog, Input) => {
             name={this.props.name}
             okLabel={okLabel}
             onDismiss={this.handleDismiss}
-            onEscKeyDown={onEscKeyDown}
-            onOverlayClick={onOverlayClick}
+            onEscKeyDown={onEscKeyDown || this.handleDismiss}
+            onOverlayClick={onOverlayClick || this.handleDismiss}
             onSelect={this.handleSelect}
             theme={this.props.theme}
             value={this.props.value}


### PR DESCRIPTION
Clicking on the `TimePicker`'s `overlay` or tapping `ESC` to dismiss the dialog wasn't working, I've added the missing fallback props as you guys did in the `DatePicker` [Here](https://github.com/react-toolbox/react-toolbox/blob/dev/components/date_picker/DatePicker.js#L149).