### PR TITLE
TypeScript: snack-bar label accepts element

### DIFF
--- a/components/snackbar/Snackbar.d.ts
+++ b/components/snackbar/Snackbar.d.ts
@@ -49,7 +49,7 @@ export interface SnackbarProps extends ReactToolbox.Props {
   /**
    * Text to display in the content.
    */
-  label?: string;
+  label?: string | JSX.Element;
   /**
    * Callback function that will be called when the button action is clicked.
    */


### PR DESCRIPTION
https://github.com/react-toolbox/react-toolbox/issues/819 allowed label to be element too but TSD hasn't been updated.
  