### PR TITLE
New prop proposal on Autocomplete component.

### DIFF
--- a/components/autocomplete/Autocomplete.d.ts
+++ b/components/autocomplete/Autocomplete.d.ts
@@ -128,6 +128,10 @@ export interface AutocompleteProps extends InputProps {
    * Additional properties passed to inner Input component.
    */
   [key: string]: any;
+  /**
+   * Array of numbers representing keyboard keys that will trigger active item creation or selection.
+   */
+  submitKeys?: Array<number>;
 }
 
 export class Autocomplete extends React.Component<AutocompleteProps, {}> { }

--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -54,6 +54,7 @@ const factory = (Chip, Input) => {
         values: PropTypes.string,
       }),
       value: PropTypes.any,
+      submitKeys: PropTypes.array
     };
 
     static defaultProps = {
@@ -67,6 +68,7 @@ const factory = (Chip, Input) => {
       showSuggestionsWhenValueIsSet: false,
       source: {},
       suggestionMatch: 'start',
+      submitKeys: [13]
     };
 
     state = {
@@ -145,9 +147,9 @@ const factory = (Chip, Input) => {
        && this.state.showAllSuggestions
      );
 
-      if (event.which === 13) {
-        this.selectOrCreateActiveItem(event);
-      }
+     if (this.props.submitKeys.includes(event.which) === true) {
+      this.selectOrCreateActiveItem(event);
+     }
     };
 
     handleQueryKeyUp = (event) => {

--- a/components/autocomplete/readme.md
+++ b/components/autocomplete/readme.md
@@ -62,6 +62,7 @@ If you want to provide a theme via context, the component key is `RTAutocomplete
 | `showSuggestionsWhenValueIsSet` | `Bool`                        | `false` | If true, the list of suggestions will not be filtered when a value is selected, until the query is modified. |
 | `suggestionMatch`               | `String`                      | `start` | Determines how suggestions are supplied. It can be `start` (query matches the start of a suggestion), `anywhere` (query matches anywhere inside the suggestion), `word` (query matches the start of a word in the suggestion) or `disabled` (disable filtering of provided source, all items are shown). |
 | `value`                         | `String`, `Array` or `Object` |         | Value or array of values currently selected component. |
+| `submitKeys`                    | `Array`                       | `[13]`  | Array of numbers representing keyboard keys that will trigger active item creation or selection. |
 
 Additional properties will be passed to the Input Component so you can use `hint`, `name` ... etc.
 

--- a/spec/components/autocomplete.js
+++ b/spec/components/autocomplete.js
@@ -50,7 +50,7 @@ class AutocompleteTest extends React.Component {
         <h5>Autocomplete</h5>
         <p>You can have a multiple or simple autocomplete.</p>
 
-        <Autocomplete
+        <Autocomplete 
           allowCreate
           keepFocusOnChange
           label="Pick multiple elements..."
@@ -59,6 +59,7 @@ class AutocompleteTest extends React.Component {
           source={this.state.countriesObject}
           suggestionMatch="anywhere"
           value={this.state.multipleArray}
+          submitKeys={[13, 188, 186]}
         />
 
         <Autocomplete


### PR DESCRIPTION
I would like to propose a new prop on Autocomplete component - 'submitKeys'. It would mean an array of numbers representing keyboard keys that will trigger active item creation or selection.

This would allow programmers to configure which keyboard keys would trigger active item creation or selection. Defaults to 13, so this change is backwards compatible.