### PR TITLE
Multiline Input "jumps" if parent element is scrollable (IE11)

### DIFF
--- a/components/input/Input.js
+++ b/components/input/Input.js
@@ -124,7 +124,6 @@ const factory = (FontIcon) => {
           : parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
 
         // resize the input to its content size
-        element.style.height = 'auto';
         element.style.height = `${element.scrollHeight + heightOffset}px`;
       }
     }


### PR DESCRIPTION
This happens if the cursor is not visible and the parent element is scrollable.

![multiline-input](https://user-images.githubusercontent.com/160042/35708588-a9eff59e-0763-11e8-9cfd-04dea399479e.gif)
