### PR TITLE
Add property for layout childrens to specify type

### DIFF
--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -64,9 +64,9 @@ const factory = (AppBar, NavDrawer, Sidebar) => {
 
     render() {
       const { children, className, theme, ...rest } = this.props;
-      const appBar = filterReactChildren(children, isAppBar)[0];
-      const navDrawer = filterReactChildren(children, isNavDrawer)[0];
-      const sidebar = filterReactChildren(children, isSidebar)[0];
+      const isNavDrawer = child =>  child.props && child.props.navDrawerBar || isComponentOfType(NavDrawer, child);
+      const isSidebar = child => child.props && child.props.layoutSidebar || isComponentOfType(Sidebar, child);
+      const isAppBar = child => child.props && child.props.layouAppBar ||isComponentOfType(AppBar, child);
       const unknown = filterReactChildren(children, isUnknown);
       const appBarFixed = appBar && appBar.props.fixed;
       const navDrawerPinned = this.isPinned(navDrawer);

--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -13,9 +13,10 @@ import breakpoints from '../utils/breakpoints';
 import { LAYOUT } from '../identifiers';
 
 const factory = (AppBar, NavDrawer, Sidebar) => {
-  const isNavDrawer = child => isComponentOfType(NavDrawer, child);
-  const isSidebar = child => isComponentOfType(Sidebar, child);
-  const isAppBar = child => isComponentOfType(AppBar, child);
+	
+  const isNavDrawer = child => child.props && child.props.layoutNavDrawer || isComponentOfType(NavDrawer, child);
+  const isSidebar = child => child.props && child.props.layoutSidebar ||  isComponentOfType(Sidebar, child);
+  const isAppBar = child => child.props && child.props.layoutAppBar ||  isComponentOfType(AppBar, child);
   const isUnknown = child => !isNavDrawer(child) && !isSidebar(child) && !isAppBar(child);
 
   class Layout extends Component {

--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -64,9 +64,9 @@ const factory = (AppBar, NavDrawer, Sidebar) => {
 
     render() {
       const { children, className, theme, ...rest } = this.props;
-      const isNavDrawer = child =>  child.props && child.props.navDrawerBar || isComponentOfType(NavDrawer, child);
-      const isSidebar = child => child.props && child.props.layoutSidebar || isComponentOfType(Sidebar, child);
-      const isAppBar = child => child.props && child.props.layouAppBar ||isComponentOfType(AppBar, child);
+      const appBar = filterReactChildren(children, isAppBar)[0];
+      const navDrawer = filterReactChildren(children, isNavDrawer)[0];
+      const sidebar = filterReactChildren(children, isSidebar)[0];
       const unknown = filterReactChildren(children, isUnknown);
       const appBarFixed = appBar && appBar.props.fixed;
       const navDrawerPinned = this.isPinned(navDrawer);


### PR DESCRIPTION
With the new version of react-hot-reloader, each component is wrapped into a proxy object. This proxy cuases that Layout Childrens such as AppBar or NavDrawer aren't updated with the correct classes and styles on Dev mode.

The solution is to add a property to those children that explicitly indicates the element type.
