### PR TITLE
[IE] - Fix issue Checkbox on IE stay focused

### DIFF
--- a/components/checkbox/Checkbox.js
+++ b/components/checkbox/Checkbox.js
@@ -41,6 +41,7 @@ const factory = (Check) => {
       if (event.pageX !== 0 && event.pageY !== 0) this.blur();
       if (!this.props.disabled && this.props.onChange) {
         this.props.onChange(!this.props.checked, event);
+        this.blur();
       }
     };
 


### PR DESCRIPTION
#### DESC:
_Checkbox component input element stay focused on IE11 after click (check)_
![2018-02-21 07-44-ie-11-checbox-focus-issue](https://user-images.githubusercontent.com/18281147/36506995-9d41da88-1758-11e8-9cd7-a6669dff8139.gif)


_The goal is to unfocus immediately to avoid such issues._