### PR TITLE
Link text has text-transform: capitalize, contrary to Material specs is removed.

### DIFF
--- a/components/link/theme.css
+++ b/components/link/theme.css
@@ -32,10 +32,6 @@
     vertical-align: middle;
   }
 
-  & > abbr {
-    text-transform: capitalize;
-  }
-
   & > small {
     font-size: var(--font-size-tiny);
     margin-left: calc(0.8 * var(--unit));


### PR DESCRIPTION
Issue #1774