### PR TITLE
Problem with Race Condition on Time Picker clock face

### DIFF
--- a/components/time_picker/TimePickerDialog.js
+++ b/components/time_picker/TimePickerDialog.js
@@ -61,7 +61,7 @@ const factory = (Dialog) => {
     }
 
     handleClockChange = (value) => {
-      this.setState({ displayTime: value });
+      setTimeout(function() { this.setState({ displayTime: value }) }, 200);
     };
 
     handleSelect = (event) => {


### PR DESCRIPTION
I am having a problem with the face on the Time Picker component. I tried to post a bug about this but you guys could not reproduce so it got closed. However, I have since figured out how to reproduce it. Our site is large and there is a lot to load so all you need is a load time of longer than 1 second or any list longer than 100 remote items being loaded and the bug will happen. I have included a zipped .mov file that shows me reproducing this bug just to show you it exists.

You open the Time Picker, press once on any hour position on the clock face, the dialog proceeds forward into choosing the minutes and yet the hour has not moved from it's initial position.

It only seems to happen on the very first click when the Time Picker has been opened. If you open it and instead click+drag in any direction this bug does not occur. It also does not occur if (after being taken to the minutes selection phase) you return back to the hour selection phase and re-select the option you wanted. I believe it's a simple race condition happening here and so that's why I added that awful quick fix. This fix is less about the 200 milliseconds wait time and more about popping this event from the next position in the Call-stack to the end. 

The code I added is really dirty as a quick fix so it's mostly just to bring your attention to the problem in some way other than just as a closable issue ticket. Hopefully you can help me to resolve this issue asap since I use this repository heavily and would like to not require self-hosted NPM packages if possible.

[bug1-edit.mov.zip](https://github.com/react-toolbox/react-toolbox/files/1833614/bug1-edit.mov.zip)
