### PR TITLE
Fix #1870: Dropdown won't close after selecting an item

### DIFF
--- a/components/dropdown/Dropdown.js
+++ b/components/dropdown/Dropdown.js
@@ -133,18 +133,6 @@ const factory = (Input) => {
       this.setState({ active: true, up });
     };
 
-    handleFocus = (event) => {
-      event.stopPropagation();
-      if (!this.props.disabled) this.open(event);
-      if (this.props.onFocus) this.props.onFocus(event);
-    };
-
-    handleBlur = (event) => {
-      event.stopPropagation();
-      if (this.state.active) this.close();
-      if (this.props.onBlur) this.props.onBlur(event);
-    }
-
     renderTemplateValue(selected) {
       const { theme } = this.props;
       const className = classnames(theme.field, {
@@ -204,8 +192,6 @@ const factory = (Input) => {
         <div
           className={className}
           data-react-toolbox="dropdown"
-          onBlur={this.handleBlur}
-          onFocus={this.handleFocus}
           tabIndex="-1"
         >
           <Input


### PR DESCRIPTION
This PR fixes the problem when using the Dropdown **with mouse** at least. Maybe some other work should make it **work with the keyboard**, for example pressing the spacebar when the dropdown is focused, then accepting ENTER and ESC (to select, and close respectively)

@javivelasco @rubenmoya Please look when having some time. I can take your ideas to continue working on this.