### PR TITLE
Update canonical link, og:url, and twitter:site

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,18 +15,18 @@
     <meta http-equiv="cleartype" content="on">
 
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:site" content="www.react-toolbox.com">
+    <meta name="twitter:site" content="react-toolbox.io">
     <meta name="twitter:title" content="React Toolbox">
     <meta name="twitter:description" content="React Toolbox is a set of React components that implement Google's Material Design specification. It's powered by CSS Modules and harmoniously integrates with your Webpack workflow. You can take a tour through our documentation website and try the components live!.">
     <meta name="twitter:image" content="images/logo.png">
 
     <meta name="og:title" content="React Toolbox">
     <meta name="og:description" content="React Toolbox is a set of React components that implement Google's Material Design specification. It's powered by CSS Modules and harmoniously integrates with your Webpack workflow. You can take a tour through our documentation website and try the components live!.">
-    <meta name="og:url" content="www.react-toolbox.com">
+    <meta name="og:url" content="react-toolbox.io">
     <meta name="og:image" content="images/logo.png">
     <meta name="og:type" content="app">
 
-    <link rel="canonical" href="http://www.react-toolbox.com/">
+    <link rel="canonical" href="http://react-toolbox.io/">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
     <link rel="stylesheet" href="docs.css">


### PR DESCRIPTION
Fixes bug described in Twitter thread and corrects Facebook and Twitter site meta tags.

Beginning:
https://twitter.com/rickydelaveaga/status/1082347347441373188

...and (current) end of the thread:
https://twitter.com/rickydelaveaga/status/1082353403869650944

Screencast of the bug in action: 
https://twitter.com/rickydelaveaga/status/1082351533998493697
@javivelasco Here is a screen recording because I wouldn’t believe it if someone wrote this to me https://twitter.com/rickydelaveaga/status/1082351533998493697/video/1

Cause was Copy action in Mobile Safari share sheet trusting:

```html
<link rel="canonical" href="http://www.react-toolbox.com/">
```

...more than its own address. Filing as a Safari bug.