### PR TITLE
allow keyboard activation of a tab by tapping space or enter

### DIFF
--- a/components/tabs/Tab.js
+++ b/components/tabs/Tab.js
@@ -50,6 +50,12 @@ const factory = (ripple, FontIcon) => {
       }
     };
 
+    handleKeyDown = (event) => {
+      if (!this.props.disabled && this.props.onClick && (event.key === ' ' || event.key === 'Enter')) {
+        this.props.onClick(event, this.props.index);
+      }
+    }
+
     render() {
       const {
         index, onActive, // eslint-disable-line
@@ -65,7 +71,7 @@ const factory = (ripple, FontIcon) => {
       }, className);
 
       return (
-        <div {...other} data-react-toolbox="tab" role="tab" tabIndex="0" className={_className} onClick={this.handleClick}>
+        <div {...other} data-react-toolbox="tab" role="tab" tabIndex="0" className={_className} onClick={this.handleClick} onKeyDown={this.handleKeyDown}>
           {icon && <FontIcon className={theme.icon} value={icon} />}
           {label}
           {children}


### PR DESCRIPTION
The issue here is that a tab can currently *take* focus (via the tabIndex={0} line in Tab.js), but I haven't found a way to *activate* the tab with the keyboard.

Let me know what you think!