### PR TITLE
Add autoFocus to InputProps

### DIFF
--- a/components/input/Input.d.ts
+++ b/components/input/Input.d.ts
@@ -146,6 +146,11 @@ export interface InputProps extends ReactToolbox.Props {
    * Current value of the input element.
    */
   value?: any;
+  /**
+   * If true, the html input has an auto-focus attribute.
+   * @default false
+   */
+  autoFocus?: boolean;
 }
 
 export class Input extends React.Component<InputProps, {}> {


### PR DESCRIPTION
In this issue https://github.com/react-toolbox/react-toolbox/issues/1547 it is described that autoFocus should work for the Input element. However, I had problems with autoFocus when using TypeScript and I saw this is missing from InputProps.d.ts. Maybe it will help someone.